### PR TITLE
Fix agent version in release pipeline yml

### DIFF
--- a/.azure-pipelines/azure-pipelines-released-version.yml
+++ b/.azure-pipelines/azure-pipelines-released-version.yml
@@ -13,7 +13,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.7.0'
+      versionSpec: '3.7.2'
       architecture: 'x64'
 
   - template: templates/setup-ci-machine.yml
@@ -28,7 +28,7 @@ jobs:
   steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '3.7.0'
+        versionSpec: '3.7.2'
         architecture: 'x64'
 
     - script: pip install --pre azure-cli --extra-index-url https://azurecliprod.blob.core.windows.net/edge


### PR DESCRIPTION
Failing pipeline url: https://dev.azure.com/ms/azure-devops-cli-extension/_build?definitionId=36&_a=summary
