### PR TITLE
Update wiki page requires if match header in the request

### DIFF
--- a/azure-devops/azext_devops/dev/team/wiki.py
+++ b/azure-devops/azext_devops/dev/team/wiki.py
@@ -143,8 +143,8 @@ def add_page(wiki, path, comment=_DEFAULT_PAGE_ADD_MESSAGE, content=None, file_p
                                              project=project, path=path, version=None, comment=comment)
 
 
-def update_page(wiki, path, comment=_DEFAULT_PAGE_UPDATE_MESSAGE, content=None, file_path=None,
-                version=None, organization=None, project=None, detect=None):
+def update_page(wiki, path, version, comment=_DEFAULT_PAGE_UPDATE_MESSAGE, content=None, file_path=None,
+                organization=None, project=None, detect=None):
     """Edit a page.
      :param wiki: Name or Id of the wiki.
     :type wiki: str

--- a/azure-devops/azext_devops/devops_sdk/client.py
+++ b/azure-devops/azext_devops/devops_sdk/client.py
@@ -66,7 +66,7 @@ class Client(object):
         return response
 
     def _send(self, http_method, location_id, version, route_values=None,
-              query_parameters=None, content=None, media_type='application/json', accept_media_type='application/json'):
+              query_parameters=None, content=None, media_type='application/json', accept_media_type='application/json', if_match=None):
         request = self._create_request_message(http_method=http_method,
                                                location_id=location_id,
                                                route_values=route_values,
@@ -85,6 +85,8 @@ class Client(object):
         # Construct headers
         headers = {'Content-Type': media_type + '; charset=utf-8',
                    'Accept': accept_media_type + ';api-version=' + negotiated_version}
+        if if_match:
+            headers['if-match'] = if_match
         if self.config.additional_headers is not None:
             for key in self.config.additional_headers:
                 headers[key] = self.config.additional_headers[key]

--- a/azure-devops/azext_devops/devops_sdk/v5_0/wiki/wiki_client.py
+++ b/azure-devops/azext_devops/devops_sdk/v5_0/wiki/wiki_client.py
@@ -115,7 +115,8 @@ class WikiClient(Client):
                               version='5.0',
                               route_values=route_values,
                               query_parameters=query_parameters,
-                              content=content)
+                              content=content,
+                              if_match=version)
         response_object = models.WikiPageResponse()
         response_object.page = self._deserialize('WikiPage', response)
         response_object.eTag = response.headers.get('ETag')


### PR DESCRIPTION
Updating a wiki page requires the version to be given as if-match header. 
The client does not support it so adding it in the client for now.

This will need to be fixed in the Azure-Devops-python client. I will separately follow up on that. 