### PR TITLE
Bug fixes : Handle long list of service connections and  Github file checkin failure  in pipeline create command

### DIFF
--- a/azure-devops/azext_devops/dev/pipelines/pipeline_create.py
+++ b/azure-devops/azext_devops/dev/pipelines/pipeline_create.py
@@ -345,7 +345,7 @@ def _create_and_get_yml_path(cix_client, repository_type, repo_id, repo_name, br
     for file in files:
         print('{index}) {file}'.format(index=count_file, file=file.path))
         count_file = count_file + 1
-
+    print('')
     if default_yml_exists and checkin_path.strip('/') == 'azure-pipelines.yml':
         print('Edits on the existing yaml can be done in the code repository.')
     else:

--- a/azure-devops/azext_devops/dev/pipelines/pipeline_create_helpers/github_api_helper.py
+++ b/azure-devops/azext_devops/dev/pipelines/pipeline_create_helpers/github_api_helper.py
@@ -167,4 +167,5 @@ def commit_file_to_github_branch(path_to_commit, content, repo_name, branch, mes
         if not response.status_code == _HTTP_CREATED_STATUS:
             raise CLIError('GitHub file checkin failed for file ({file}). Status Code ({code}).'.format(
                 file=path_to_commit, code=response.status_code))
-    raise CLIError('GitHub file checkin failed. File path or content is empty.')
+    else:
+        raise CLIError('GitHub file checkin failed. File path or content is empty.')

--- a/azure-devops/azext_devops/dev/pipelines/pipeline_create_helpers/github_api_helper.py
+++ b/azure-devops/azext_devops/dev/pipelines/pipeline_create_helpers/github_api_helper.py
@@ -166,5 +166,5 @@ def commit_file_to_github_branch(path_to_commit, content, repo_name, branch, mes
         logger.debug(response)
         if not response.status_code == _HTTP_CREATED_STATUS:
             raise CLIError('GitHub file checkin failed for file ({file}). Status Code ({code}).'.format(
-                           file=path_to_commit, code=response.status_code))
+                file=path_to_commit, code=response.status_code))
     raise CLIError('GitHub file checkin failed. File path or content is empty.')

--- a/azure-devops/azext_devops/dev/pipelines/pipeline_create_helpers/github_api_helper.py
+++ b/azure-devops/azext_devops/dev/pipelines/pipeline_create_helpers/github_api_helper.py
@@ -161,7 +161,10 @@ def commit_file_to_github_branch(path_to_commit, content, repo_name, branch, mes
         }
         token = get_github_pat_token()
         logger.warning('Checking in file %s in the Github repository %s', path_to_commit, repo_name)
-        # Todo: Validate response and return status from function
         response = requests.put(url_for_github_file_api, auth=('', token),
                                 json=request_body, headers=headers)
         logger.debug(response)
+        if not response.status_code == _HTTP_CREATED_STATUS:
+            raise CLIError('GitHub file checkin failed for file ({file}). Status Code ({code}).'.format(
+                           file=path_to_commit, code=response.status_code))
+    raise CLIError('GitHub file checkin failed. File path or content is empty.')

--- a/azure-devops/azext_devops/dev/pipelines/pipeline_create_helpers/pipelines_resource_provider.py
+++ b/azure-devops/azext_devops/dev/pipelines/pipeline_create_helpers/pipelines_resource_provider.py
@@ -22,6 +22,8 @@ def get_github_service_endpoint(organization, project):
     Service endpoint connection name is asked as input from the user, if the environment is non interative
     name is set to default  AzureDevopsCliCreatePipelineFlow
     """
+    from azext_devops.dev.common.identities import get_current_identity, get_account_from_identity
+    authenticated_user_unique_id = get_account_from_identity(get_current_identity(organization))
     se_client = get_service_endpoint_client(organization)
     existing_service_endpoints = _get_service_endpoints(organization, project, 'github')
     service_endpoints_choice_list = ['Create new GitHub service connection']
@@ -30,9 +32,10 @@ def get_github_service_endpoint(organization, project):
     for endpoint in existing_service_endpoints:
         if endpoint.authorization.scheme == 'InstallationToken':
             service_endpoints_choice_list.append('{} {}'.format(endpoint.name, '(Recommended)'))
-        else:
+            github_service_endpoints.append(endpoint)
+        elif authenticated_user_unique_id == endpoint.created_by.unique_name:
             service_endpoints_choice_list.append('{}'.format(endpoint.name))
-        github_service_endpoints.append(endpoint)
+            github_service_endpoints.append(endpoint)
     if github_service_endpoints:
         choice = prompt_user_friendly_choice_list(
             "Which service connection do you want to use to communicate with GitHub?",

--- a/azure-devops/azext_devops/dev/pipelines/pipeline_create_helpers/pipelines_resource_provider.py
+++ b/azure-devops/azext_devops/dev/pipelines/pipeline_create_helpers/pipelines_resource_provider.py
@@ -34,8 +34,6 @@ def get_github_service_endpoint(organization, project):
             service_endpoints_choice_list.append('{}'.format(endpoint.name))
             github_service_endpoints.append(endpoint)
     if github_service_endpoints:
-        import pdb
-        pdb.set_trace()
         choice = prompt_user_friendly_choice_list(
             "Which service connection do you want to use to communicate with GitHub?",
             service_endpoints_choice_list)

--- a/azure-devops/azext_devops/dev/pipelines/pipeline_create_helpers/pipelines_resource_provider.py
+++ b/azure-devops/azext_devops/dev/pipelines/pipeline_create_helpers/pipelines_resource_provider.py
@@ -29,27 +29,25 @@ def get_github_service_endpoint(organization, project):
     github_service_endpoints = []
     choice = 0
     for endpoint in existing_service_endpoints:
-        if (endpoint.authorization.scheme == 'InstallationToken' or 
-            authenticated_user_unique_id == endpoint.created_by.unique_name):
+        if (endpoint.authorization.scheme == 'InstallationToken' or
+                authenticated_user_unique_id == endpoint.created_by.unique_name):
             service_endpoints_choice_list.append('{}'.format(endpoint.name))
             github_service_endpoints.append(endpoint)
     if github_service_endpoints:
         choice = prompt_user_friendly_choice_list(
-            "Which service connection do you want to use to communicate with GitHub?",
-            service_endpoints_choice_list)
+            "Which service connection do you want to use to communicate with GitHub?", service_endpoints_choice_list)
         if choice > 0:
-            logger.debug('Using service endpoint index (%s) name (%s)',
-                           choice, github_service_endpoints[choice - 1].name)
+            logger.debug(
+                'Using service endpoint index (%s) name (%s)', choice, github_service_endpoints[choice - 1].name)
             return github_service_endpoints[choice - 1].id
     logger.debug("Creating a new service endpoint.")
     github_pat = get_github_pat_token()
     se_name = prompt_not_empty('Enter a service connection name to create? ')
     print('')
-    service_endpoint_authorization = EndpointAuthorization(parameters={'accessToken': github_pat},
-                                                            scheme='PersonalAccessToken')
-    service_endpoint_to_create = ServiceEndpoint(authorization=service_endpoint_authorization,
-                                                    name=se_name, type='github',
-                                                    url='https://github.com/')
+    service_endpoint_authorization = EndpointAuthorization(
+        parameters={'accessToken': github_pat}, scheme='PersonalAccessToken')
+    service_endpoint_to_create = ServiceEndpoint(
+        authorization=service_endpoint_authorization, name=se_name, type='github', url='https://github.com/')
     return se_client.create_service_endpoint(service_endpoint_to_create, project).id
 
 

--- a/azure-devops/azext_devops/dev/pipelines/pipeline_create_helpers/pipelines_resource_provider.py
+++ b/azure-devops/azext_devops/dev/pipelines/pipeline_create_helpers/pipelines_resource_provider.py
@@ -19,8 +19,7 @@ def get_github_service_endpoint(organization, project):
     This will try to create a GitHub service connection if there is no existing one in the project
     GitHub pat token will be asked for interactively or can be provided
     by setting the Environment variable AZ_DEVOPS_GITHUB_PAT_ENVKEY.
-    Service endpoint connection name is asked as input from the user, if the environment is non interative
-    name is set to default  AzureDevopsCliCreatePipelineFlow
+    Service endpoint connection name is asked as input from the user
     """
     from azext_devops.dev.common.identities import get_current_identity, get_account_from_identity
     authenticated_user_unique_id = get_account_from_identity(get_current_identity(organization))
@@ -30,28 +29,30 @@ def get_github_service_endpoint(organization, project):
     github_service_endpoints = []
     choice = 0
     for endpoint in existing_service_endpoints:
-        if endpoint.authorization.scheme == 'InstallationToken':
-            service_endpoints_choice_list.append('{} {}'.format(endpoint.name, '(Recommended)'))
-            github_service_endpoints.append(endpoint)
-        elif authenticated_user_unique_id == endpoint.created_by.unique_name:
+        if (endpoint.authorization.scheme == 'InstallationToken' or 
+            authenticated_user_unique_id == endpoint.created_by.unique_name):
             service_endpoints_choice_list.append('{}'.format(endpoint.name))
             github_service_endpoints.append(endpoint)
     if github_service_endpoints:
+        import pdb
+        pdb.set_trace()
         choice = prompt_user_friendly_choice_list(
             "Which service connection do you want to use to communicate with GitHub?",
             service_endpoints_choice_list)
-    if choice == 0:
-        logger.debug("Creating a new service endpoint.")
-        github_pat = get_github_pat_token()
-        se_name = prompt_not_empty('Enter a service endpoint name to create? ')
-        print('')
-        service_endpoint_authorization = EndpointAuthorization(parameters={'accessToken': github_pat},
-                                                               scheme='PersonalAccessToken')
-        service_endpoint_to_create = ServiceEndpoint(authorization=service_endpoint_authorization,
-                                                     name=se_name, type='github',
-                                                     url='https://github.com/')
-        return se_client.create_service_endpoint(service_endpoint_to_create, project).id
-    return existing_service_endpoints[choice - 1].id
+        if choice > 0:
+            logger.debug('Using service endpoint index (%s) name (%s)',
+                           choice, github_service_endpoints[choice - 1].name)
+            return github_service_endpoints[choice - 1].id
+    logger.debug("Creating a new service endpoint.")
+    github_pat = get_github_pat_token()
+    se_name = prompt_not_empty('Enter a service connection name to create? ')
+    print('')
+    service_endpoint_authorization = EndpointAuthorization(parameters={'accessToken': github_pat},
+                                                            scheme='PersonalAccessToken')
+    service_endpoint_to_create = ServiceEndpoint(authorization=service_endpoint_authorization,
+                                                    name=se_name, type='github',
+                                                    url='https://github.com/')
+    return se_client.create_service_endpoint(service_endpoint_to_create, project).id
 
 
 def _get_service_endpoints(organization, project, endpoint_type=None):


### PR DESCRIPTION
Bug Fixes in az pipeline create command: 
1. Handle long list of service connections in pipeline create (filter the list to only connections create by the user or App connections
1. Handle github file checkin failures by raising appropriate error