### PR TITLE
Regression fix for knack config file chaining functionality

### DIFF
--- a/.azure-pipelines/templates/install-azure-cli-edge.yml
+++ b/.azure-pipelines/templates/install-azure-cli-edge.yml
@@ -1,7 +1,3 @@
 steps:
-  #  commented out for now because DevOps CLI is broken with latest Azure CLI build
-  # - script: 'pip install --pre azure-cli --extra-index-url https://azurecliprod.blob.core.windows.net/edge'
-  #   displayName: 'Install Azure CLI Edge'
-
-  - script: pip install azure-cli
-    displayName: 'Install Azure CLI released version (in place of edge due to active bug)'
+  - script: 'pip install --pre azure-cli --extra-index-url https://azurecliprod.blob.core.windows.net/edge'
+    displayName: 'Install Azure CLI Edge'

--- a/azure-devops/azext_devops/dev/common/config.py
+++ b/azure-devops/azext_devops/dev/common/config.py
@@ -31,8 +31,7 @@ AZ_DEVOPS_GLOBAL_CONFIG_PATH = os.path.join(AZ_DEVOPS_GLOBAL_CONFIG_DIR, CONFIG_
 
 class AzDevopsConfig(CLIConfig):
     def __init__(self, config_dir=AZ_DEVOPS_GLOBAL_CONFIG_DIR, config_env_var_prefix=CLI_ENV_VARIABLE_PREFIX):
-        super(AzDevopsConfig, self).__init__(config_dir=config_dir, config_env_var_prefix=config_env_var_prefix,
-                                             use_local_config=True)
+        super(AzDevopsConfig, self).__init__(config_dir=config_dir, config_env_var_prefix=config_env_var_prefix)
         self.config_parser = get_config_parser()
 
 
@@ -40,24 +39,26 @@ azdevops_config = AzDevopsConfig()
 azdevops_config.config_parser.read(AZ_DEVOPS_GLOBAL_CONFIG_PATH)
 
 
-def set_global_config(config):
-    ensure_dir(AZ_DEVOPS_GLOBAL_CONFIG_DIR)
-    with open(AZ_DEVOPS_GLOBAL_CONFIG_PATH, 'w') as configfile:
-        config.write(configfile)
-    os.chmod(AZ_DEVOPS_GLOBAL_CONFIG_PATH, stat.S_IRUSR | stat.S_IWUSR)
-    # reload config
-    azdevops_config.config_parser.read(AZ_DEVOPS_GLOBAL_CONFIG_PATH)
+# def set_global_config(config):
+# ensure_dir(AZ_DEVOPS_GLOBAL_CONFIG_DIR)
+# with open(AZ_DEVOPS_GLOBAL_CONFIG_PATH, 'w') as configfile:
+#     config.write(configfile)
+# os.chmod(AZ_DEVOPS_GLOBAL_CONFIG_PATH, stat.S_IRUSR | stat.S_IWUSR)
+# # reload config
+# azdevops_config.config_parser.read(AZ_DEVOPS_GLOBAL_CONFIG_PATH)
 
 
 def set_global_config_value(section, option, value):
-    config = get_config_parser()
-    config.read(AZ_DEVOPS_GLOBAL_CONFIG_PATH)
-    try:
-        config.add_section(section)
-    except configparser.DuplicateSectionError:
-        pass
-    config.set(section, option, _normalize_config_value(value))
-    set_global_config(config)
+    # config = get_config_parser()
+    # config.read(AZ_DEVOPS_GLOBAL_CONFIG_PATH)
+    # try:
+    #     config.add_section(section)
+    # except configparser.DuplicateSectionError:
+    #     pass
+    # config.set(section, option, _normalize_config_value(value))
+    # set_global_config(config)
+    azdevops_config.set_value(section, option, _normalize_config_value(value))
+    azdevops_config.config_parser.read(AZ_DEVOPS_GLOBAL_CONFIG_PATH)
 
 
 def _normalize_config_value(value):

--- a/azure-devops/azext_devops/dev/common/config.py
+++ b/azure-devops/azext_devops/dev/common/config.py
@@ -4,8 +4,6 @@
 # --------------------------------------------------------------------------------------------
 
 import os
-import stat
-from six.moves import configparser
 
 from knack.config import CLIConfig, get_config_parser
 from knack.util import ensure_dir
@@ -39,24 +37,7 @@ azdevops_config = AzDevopsConfig()
 azdevops_config.config_parser.read(AZ_DEVOPS_GLOBAL_CONFIG_PATH)
 
 
-# def set_global_config(config):
-# ensure_dir(AZ_DEVOPS_GLOBAL_CONFIG_DIR)
-# with open(AZ_DEVOPS_GLOBAL_CONFIG_PATH, 'w') as configfile:
-#     config.write(configfile)
-# os.chmod(AZ_DEVOPS_GLOBAL_CONFIG_PATH, stat.S_IRUSR | stat.S_IWUSR)
-# # reload config
-# azdevops_config.config_parser.read(AZ_DEVOPS_GLOBAL_CONFIG_PATH)
-
-
 def set_global_config_value(section, option, value):
-    # config = get_config_parser()
-    # config.read(AZ_DEVOPS_GLOBAL_CONFIG_PATH)
-    # try:
-    #     config.add_section(section)
-    # except configparser.DuplicateSectionError:
-    #     pass
-    # config.set(section, option, _normalize_config_value(value))
-    # set_global_config(config)
     azdevops_config.set_value(section, option, _normalize_config_value(value))
     azdevops_config.config_parser.read(AZ_DEVOPS_GLOBAL_CONFIG_PATH)
 

--- a/azure-devops/azext_devops/dev/common/config.py
+++ b/azure-devops/azext_devops/dev/common/config.py
@@ -31,7 +31,8 @@ AZ_DEVOPS_GLOBAL_CONFIG_PATH = os.path.join(AZ_DEVOPS_GLOBAL_CONFIG_DIR, CONFIG_
 
 class AzDevopsConfig(CLIConfig):
     def __init__(self, config_dir=AZ_DEVOPS_GLOBAL_CONFIG_DIR, config_env_var_prefix=CLI_ENV_VARIABLE_PREFIX):
-        super(AzDevopsConfig, self).__init__(config_dir=config_dir, config_env_var_prefix=config_env_var_prefix)
+        super(AzDevopsConfig, self).__init__(config_dir=config_dir, config_env_var_prefix=config_env_var_prefix,
+                                             use_local_config=True)
         self.config_parser = get_config_parser()
 
 

--- a/azure-devops/azext_devops/dev/team/configure.py
+++ b/azure-devops/azext_devops/dev/team/configure.py
@@ -75,7 +75,7 @@ def print_current_configuration(file_config=None):
     env_vars = [ev for ev in os.environ if ev.startswith(CLI_ENV_VARIABLE_PREFIX)]
     if env_vars:
         print(MSG_HEADING_ENV_VARS)
-        print('\n'.join(['{} = {}'.format(ev, os.environ[ev]) for ev in env_vars]))
+        print('\n'.join(['{}'.format(ev) for ev in env_vars]))
 
 
 MSG_INTRO = '\nWelcome to the Azure DevOps CLI! This command will guide you through setting some default values.\n'


### PR DESCRIPTION
**Issue**: Configuration read is failing and hence tests were failing since organization and project are set via config in tests

**Reason**: Breaking change: Knack has introduced the concept of scoped configurations which allows chaining of config files. For back compat they allow not using this feature.
The new setter function added in the same PR if used will handle setting the values such that they can be retrieved using the getter. PR link - https://github.com/Microsoft/knack/pull/148

**Fix:** Used the new knack setter function to be consistent in reading and writing the file using knack 
 CLIConfig class functions. 

**Fix 2**:
Also making a change to not  display the value of environment variables anymore in config list command. Since it might end up displaying secrets set in environment variables. 
