### PR TITLE
Removed preview text for Universal Packages help.

### DIFF
--- a/azure-devops/azext_devops/dev/artifacts/_help.py
+++ b/azure-devops/azext_devops/dev/artifacts/_help.py
@@ -15,6 +15,6 @@ def load_artifacts_help():
 
     helps['artifacts universal'] = """
         type: group
-        short-summary: (PREVIEW) Manage Universal Packages
+        short-summary: Manage Universal Packages
         long-summary:
     """


### PR DESCRIPTION
I was using Universal Packages and noticed that the preview message is still in the help. Thought I would submit a PR to address that now that it is GA.