### PR TITLE
Git alias fix for windows and tests

### DIFF
--- a/azure-devops/azext_devops/dev/common/git.py
+++ b/azure-devops/azext_devops/dev/common/git.py
@@ -190,8 +190,8 @@ def _get_alias_key(alias):
 
 
 def _get_alias_value(command):
-    mime = '.cmd' if 'win' in sys.platform else ''
-    return f'!f() {{ exec az{ mime } { command } \"$@\"; }}; f'
+    mime = '.cmd' if sys.platform.lower().startswith('win') else ''
+    return '!f() { exec az' + mime + ' ' + command + ' \"$@\"; }; f'
 
 
 _git_remotes = {}

--- a/azure-devops/azext_devops/dev/common/git.py
+++ b/azure-devops/azext_devops/dev/common/git.py
@@ -190,7 +190,8 @@ def _get_alias_key(alias):
 
 
 def _get_alias_value(command):
-    return '!f() { exec az ' + command + ' \"$@\"; }; f'
+    mime = '.cmd' if 'win' in sys.platform else ''
+    return f'!f() {{ exec az{ mime } { command } \"$@\"; }}; f'
 
 
 _git_remotes = {}

--- a/tests/test_gitAliasTest.py
+++ b/tests/test_gitAliasTest.py
@@ -1,0 +1,12 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+import subprocess
+from azure.cli.testsdk import ScenarioTest
+
+class TestGitAliasing(ScenarioTest):
+    def test_git_aliases_pr_repo(self):
+        self.cmd('az devops configure --use-git-aliases')
+        repo_help = subprocess.check_output('git repo -h', shell=True)
+        pr_help = subprocess.check_output('git pr -h', shell=True)


### PR DESCRIPTION
Please make sure the code is following contribution guidelines in CONTRIBUTING.md

 - [x] : This PR has a corresponding issue open in the Repository. #593 
 - [x] : Approach is signed off on the issue.

In our pipeline the windows machine does not use the MSI installer hence the issue is not reproducible there. 
Just to show a test fail scenario I changed the code to alias the command as az1 instead of az and here is the pipeline failure link - https://dev.azure.com/ms/azure-devops-cli-extension/_build/results?buildId=16747&view=ms.vss-test-web.build-test-results-tab