### PR TITLE
Update samples.md - fixing command signature

### DIFF
--- a/doc/samples.md
+++ b/doc/samples.md
@@ -62,7 +62,7 @@ If you are working in a local check out of a repository, you can simply run `az 
 You can also configure the Azure Devops Extension to add git aliases for common git-based Azure Repos commands like creating or adding reviewers to pull requests. This can be enabled by running the following command:
 
 ```bash
-az devops configure --use-git-alias yes
+az devops configure --use-git-alias true
 ```
 
 This will alias all `az repos` commands to `git repo` and all `az repos pr` commands to `git pr`.


### PR DESCRIPTION
The `az devops configure --use-git-alias yes` command usage is wrong. This fixes #651

Please make sure the code is following contribution guidelines in CONTRIBUTING.md

 - [X] : This PR has a corresponding issue open in the Repository.
 - [X] : Approach is signed off on the issue.
