### PR TITLE
Fix invalid org name handling in configure and resolve

### DIFF
--- a/azure-devops/azext_devops/dev/common/services.py
+++ b/azure-devops/azext_devops/dev/common/services.py
@@ -294,8 +294,8 @@ def get_base_url(organization):
 
 def _team_organization_arg_error():
     return CLIError('--organization must be specified. The value should be the URI of your Azure DevOps '
-                    'organization, for example: https://dev.azure.com/MyOrganization/ or your Azure DevOps Server organization. '
-                    'You can set a default value by running: az devops configure --defaults '
+                    'organization, for example: https://dev.azure.com/MyOrganization/ or your Azure DevOps Server '
+                    'organization. You can set a default value by running: az devops configure --defaults '
                     'organization=https://dev.azure.com/MyOrganization/. For auto detection to work '
                     '(--detect true), you must be in a local Git directory that has a "remote" referencing a '
                     'Azure DevOps or Azure DevOps Server repository.')

--- a/azure-devops/azext_devops/dev/common/services.py
+++ b/azure-devops/azext_devops/dev/common/services.py
@@ -294,11 +294,11 @@ def get_base_url(organization):
 
 def _team_organization_arg_error():
     return CLIError('--organization must be specified. The value should be the URI of your Azure DevOps '
-                    'organization, for example: https://dev.azure.com/MyOrganization/ or your TFS organization. '
+                    'organization, for example: https://dev.azure.com/MyOrganization/ or your Azure DevOps Server organization. '
                     'You can set a default value by running: az devops configure --defaults '
                     'organization=https://dev.azure.com/MyOrganization/. For auto detection to work '
                     '(--detect true), you must be in a local Git directory that has a "remote" referencing a '
-                    'Azure DevOps or TFS repository.')
+                    'Azure DevOps or Azure DevOps Server repository.')
 
 
 def _raise_team_project_arg_error():

--- a/azure-devops/azext_devops/dev/common/services.py
+++ b/azure-devops/azext_devops/dev/common/services.py
@@ -30,7 +30,7 @@ from .const import (DEFAULTS_SECTION,
 from ._credentials import get_credential
 from .git import get_remote_url
 from .vsts_git_url_info import VstsGitUrlInfo
-from .uri import uri_parse_instance_from_git_uri
+from .uri import uri_parse_instance_from_git_uri, is_valid_url
 from .uuid import is_uuid
 from .telemetry import vsts_tracking_data, init_telemetry
 
@@ -344,6 +344,8 @@ def resolve_instance_project_and_repo(
         else:
             projectFromConfig = _resolve_project_from_config(project, False)
             vsts_tracking_data.properties[PROJECT_IGNORED_FROM_CONFIG] = projectFromConfig is not None
+    if not is_valid_url(organization):
+        raise _team_organization_arg_error()
     if project_required and project is None:
         _raise_team_project_arg_error()
     if repo_required and repo is None:

--- a/azure-devops/azext_devops/dev/common/uri.py
+++ b/azure-devops/azext_devops/dev/common/uri.py
@@ -37,3 +37,10 @@ def uri_parse_instance_from_git_uri(uri):
             return parsed_uri.scheme + "://" + parsed_uri.hostname + "/" + org_name
 
     return uri
+
+
+def is_valid_url(url):
+    parsed_url = uri_parse(url)
+    if not parsed_url.scheme or not parsed_url.netloc:
+        return False
+    return True

--- a/azure-devops/azext_devops/dev/team/configure.py
+++ b/azure-devops/azext_devops/dev/team/configure.py
@@ -84,7 +84,7 @@ def _validate_configuration(key, value):
     if key == DEVOPS_ORGANIZATION_DEFAULT:
         # value can be '' or a valid url
         if not value == '' and not is_valid_url(value):
-            raise CLIError('Organization should be a valid Azure DevOps or TFS repository url. '
+            raise CLIError('Organization should be a valid Azure DevOps or Azure DevOps Server repository url. '
                            'See command help for details.')
 
 

--- a/azure-devops/azext_devops/test/common/test_services.py
+++ b/azure-devops/azext_devops/test/common/test_services.py
@@ -66,11 +66,11 @@ class TestServicesMethods(unittest.TestCase):
         self.assertEqual(str(exc.exception), self.ORG_ERROR_STRING)
     
     ORG_ERROR_STRING = ('--organization must be specified. The value should be the URI of your Azure DevOps '
-                    'organization, for example: https://dev.azure.com/MyOrganization/ or your TFS organization. '
+                    'organization, for example: https://dev.azure.com/MyOrganization/ or your Azure DevOps Server organization. '
                     'You can set a default value by running: az devops configure --defaults '
                     'organization=https://dev.azure.com/MyOrganization/. For auto detection to work '
                     '(--detect true), you must be in a local Git directory that has a "remote" referencing a '
-                    'Azure DevOps or TFS repository.')
+                    'Azure DevOps or Azure DevOps Server repository.')
 
 if __name__ == '__main__':
     unittest.main()

--- a/azure-devops/azext_devops/test/common/test_services.py
+++ b/azure-devops/azext_devops/test/common/test_services.py
@@ -19,6 +19,7 @@ from azext_devops.dev.common.telemetry import (set_tracking_data,
 
 from azext_devops.dev.common.services import (get_connection,
                                               clear_connection_cache,
+                                              resolve_instance,
                                               resolve_instance_project_and_repo)
 
 
@@ -50,7 +51,7 @@ class TestServicesMethods(unittest.TestCase):
     def test_resolve_instance_project_and_repo(self):
         try:
             resolve_instance_project_and_repo(detect='false',
-                                              organization='',
+                                              organization='https://dev.azure.com/someorg',
                                               project='',
                                               project_required=False,
                                               repo=None,
@@ -59,6 +60,17 @@ class TestServicesMethods(unittest.TestCase):
         except CLIError as ex:
             self.assertEqual(str(ex), '--repository must be specified')
 
+    def test_resolve_instance_should_fail_for_invalid_org_url(self):
+        with self.assertRaises(Exception) as exc:
+            resolve_instance(organization='myorg', detect=False)
+        self.assertEqual(str(exc.exception), self.ORG_ERROR_STRING)
+    
+    ORG_ERROR_STRING = ('--organization must be specified. The value should be the URI of your Azure DevOps '
+                    'organization, for example: https://dev.azure.com/MyOrganization/ or your TFS organization. '
+                    'You can set a default value by running: az devops configure --defaults '
+                    'organization=https://dev.azure.com/MyOrganization/. For auto detection to work '
+                    '(--detect true), you must be in a local Git directory that has a "remote" referencing a '
+                    'Azure DevOps or TFS repository.')
 
 if __name__ == '__main__':
     unittest.main()

--- a/azure-devops/azext_devops/test/team/test_configure.py
+++ b/azure-devops/azext_devops/test/team/test_configure.py
@@ -4,15 +4,55 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-from azext_devops.dev.team.configure import (print_current_configuration)
+try:
+    # Attempt to load mock (works on Python 3.3 and above)
+    from unittest.mock import patch
+except ImportError:
+    # Attempt to load mock (works on Python version below 3.3)
+    from mock import patch
+from azext_devops.dev.common.const import DEFAULTS_SECTION
+from azext_devops.dev.team.configure import print_current_configuration, configure
+from azext_devops.test.utils.authentication import AuthenticatedTests
+from azext_devops.dev.common.services import clear_connection_cache
 
+class TestConfigureMethods(AuthenticatedTests):
 
-class TestConfigureMethods(unittest.TestCase):
+    _TEST_DEVOPS_ORGANIZATION = 'https://someorganization.visualstudio.com'
+
+    def setUp(self):
+        self.authentication_setup()
+        self.set_config_patcher = patch('azext_devops.dev.team.configure.set_global_config_value')
+        self.mock_set_config = self.set_config_patcher.start()
+
+        #clear connection cache before running each test
+        clear_connection_cache()
+
+    def tearDown(self):
+        patch.stopall()
 
     def test_print_current_configuration(self):
         # simple validation that we don't get an exception
         print_current_configuration()
+    
+    def test_setting_invalid_org_url_throws_error(self):
+        with self.assertRaises(Exception) as exc:
+            configure(defaults=['organization=abc'])
+        self.assertEqual(str(exc.exception),r'Organization should be a valid Azure DevOps or TFS repository url. See command help for details.')
+        self.mock_set_config.assert_not_called()
 
+    def test_setting_valid_org_url_should_work(self):
+        configure(defaults=['organization={}'.format(self._TEST_DEVOPS_ORGANIZATION)])
+        self.mock_set_config.assert_called_once_with(section=DEFAULTS_SECTION, option='organization', value=self._TEST_DEVOPS_ORGANIZATION)
+
+    def test_setting_org_to_blank_should_succeed(self):
+        configure(defaults=["organization="])
+        self.mock_set_config.assert_called_once_with(section=DEFAULTS_SECTION, option='organization', value='')
+
+    def test_setting_invalid_Default_key_should_fail(self):
+        with self.assertRaises(Exception) as exc:
+            configure(defaults=["abcd=abcd"])
+        self.assertEqual(str(exc.exception), r"usage error: invalid default value setup. Supported values are ['organization', 'project'].")
+        self.mock_set_config.assert_not_called()
 
 if __name__ == '__main__':
     unittest.main()

--- a/azure-devops/azext_devops/test/team/test_configure.py
+++ b/azure-devops/azext_devops/test/team/test_configure.py
@@ -37,7 +37,7 @@ class TestConfigureMethods(AuthenticatedTests):
     def test_setting_invalid_org_url_throws_error(self):
         with self.assertRaises(Exception) as exc:
             configure(defaults=['organization=abc'])
-        self.assertEqual(str(exc.exception),r'Organization should be a valid Azure DevOps or TFS repository url. See command help for details.')
+        self.assertEqual(str(exc.exception),r'Organization should be a valid Azure DevOps or Azure DevOps Server repository url. See command help for details.')
         self.mock_set_config.assert_not_called()
 
     def test_setting_valid_org_url_should_work(self):


### PR DESCRIPTION
1. Handled in Configure command so ```az devops configure --default organization=abc``` fails with error 
```"Organization should be a valid Azure DevOps or TFS repository url. See command help for details."```.

1. Handled in resolve function which is called by each command so command like ```az devops project list --org abc``` will fail with error - ```"--organization must be specified. The value should be the URI of your Azure DevOps organization, for example: https://dev.azure.com/MyOrganization/ or your TFS organization. You can set a default value by running: az devops configure --defaults 'organization=https://dev.azure.com/MyOrganization/. For auto detection to work (--detect true), you must be in a local Git directory that has a "remote" referencing a Azure DevOps or TFS repository.".``` 

Please make sure the code is following contribution guidelines in CONTRIBUTING.md

 - [x] : This PR has a corresponding issue open in the Repository. #538 #429 
 - [x] : Approach is signed off on the issue.
