### PR TITLE
Open-file in editor should not fail if default editor is not set for the file type

### DIFF
--- a/azure-devops/azext_devops/dev/common/utils.py
+++ b/azure-devops/azext_devops/dev/common/utils.py
@@ -37,8 +37,7 @@ def open_file(filepath):
     if platform.system() == 'Darwin':       # macOS
         subprocess.call(('open', filepath))
     elif platform.system() == 'Windows':    # Windows
-        # disable pylint warning since we run pylint on linux agent and startfile is a windows only function
-        os.system(filepath)  # pylint: disable=no-member
+        os.system(filepath)
     else:                                   # linux variants
         subprocess.call(('xdg-open', filepath))
 

--- a/azure-devops/azext_devops/dev/common/utils.py
+++ b/azure-devops/azext_devops/dev/common/utils.py
@@ -38,7 +38,7 @@ def open_file(filepath):
         subprocess.call(('open', filepath))
     elif platform.system() == 'Windows':    # Windows
         # disable pylint warning since we run pylint on linux agent and startfile is a windows only function
-        os.startfile(filepath)  # pylint: disable=no-member
+        os.system(filepath)  # pylint: disable=no-member
     else:                                   # linux variants
         subprocess.call(('xdg-open', filepath))
 


### PR DESCRIPTION
Fix to error #716. Now if there is no default program to open yaml files it will show the program chooser

Please make sure the code is following contribution guidelines in CONTRIBUTING.md

 - [ ] : This PR has a corresponding issue open in the Repository.
 - [ ] : Approach is signed off on the issue.
