### PR TITLE
Allow creating pipeline variables and variable-group variables as empty strings

### DIFF
--- a/azure-devops/azext_devops/dev/pipelines/pipeline_variables.py
+++ b/azure-devops/azext_devops/dev/pipelines/pipeline_variables.py
@@ -60,7 +60,8 @@ def pipeline_variable_add(name, pipeline_id=None, pipeline_name=None, value=None
         if secret:
             value = _get_value_from_env_or_stdin(var_name=name)
         else:
-            raise CLIError('--value is required as parameter for non secret variable.')
+            value = ''
+            logger.debug('--value is being set to \'\', since --value was not speficied.')
 
     pipeline_definition.variables[name] = BuildDefinitionVariable(allow_override=allow_override, is_secret=secret,
                                                                   value=value)

--- a/azure-devops/azext_devops/dev/pipelines/variable_group.py
+++ b/azure-devops/azext_devops/dev/pipelines/variable_group.py
@@ -190,7 +190,8 @@ def variable_group_variable_add(group_id, name, value=None, secret=None,
         if secret:
             value = _get_value_from_env_or_stdin(var_name=name)
         else:
-            raise CLIError('--value is required as parameter for non secret variable.')
+            value = ''
+            logger.debug('--value is being set to \'\', since --value was not speficied.')
 
     var_group.variables[name] = VariableValue(is_secret=secret, value=value)
     updated_variables = client.update_variable_group(group=var_group, project=project, group_id=group_id).variables


### PR DESCRIPTION
Please make sure the code is following contribution guidelines in CONTRIBUTING.md

 - [ ] : This PR has a corresponding issue open in the Repository. Fixes #756 
 - [ ] : Approach is signed off on the issue.


Azure CLI does not allow the use to specify as param as **--value ''**, in this case we make it '' for case when --value is skipped. 
Note that we cannot do that in update so in case of update the restriction will still apply that the user cannot set the value to none. 