### PR TITLE
Update PRReportGeneration.ps1

### DIFF
--- a/examples/PRReportGeneration.ps1
+++ b/examples/PRReportGeneration.ps1
@@ -28,7 +28,7 @@ while($continueFetching)
     {
         $prClosedDateInString = $pr | Select-Object -ExpandProperty closedDate
         Write-Host -NoNewline "."
-        $prClosedData = [datetime]::ParseExact($prClosedDateInString.SubString(0,10),'yyyy-mm-dd', $null)
+        $prClosedData = [datetime]::ParseExact($prClosedDateInString.SubString(0,10),'yyyy-MM-dd', $null)
         $prId = $pr | Select-Object -ExpandProperty pullRequestId        
 
         $prDetails = az repos pr show --org $org --id $prId -o json | ConvertFrom-Json


### PR DESCRIPTION
The datetime parsing logic interprets the month as minutes instead and so the parsed datetime is incorrect causing the loop to exit prematurely. Small fix to interpret as month instead.

