### PR TITLE
Deprecate feedback command

### DIFF
--- a/azure-devops/azext_devops/dev/team/commands.py
+++ b/azure-devops/azext_devops/dev/team/commands.py
@@ -96,7 +96,7 @@ def load_team_commands(self, _):
         g.command('logout', 'credential_clear')
 
     with self.command_group('devops', command_type=feedbackOps) as g:
-        g.command('feedback', 'feedback', deprecate_info=g.deprecate(redirect='az feedback', target='feedback', hide=True))
+        g.command('feedback', 'feedback', deprecate_info=g.deprecate(redirect='az feedback', hide=True))
 
     with self.command_group('devops', command_type=configureOps) as g:
         g.command('configure', 'configure')

--- a/azure-devops/azext_devops/dev/team/commands.py
+++ b/azure-devops/azext_devops/dev/team/commands.py
@@ -96,7 +96,7 @@ def load_team_commands(self, _):
         g.command('logout', 'credential_clear')
 
     with self.command_group('devops', command_type=feedbackOps) as g:
-        g.command('feedback', 'feedback')
+        g.command('feedback', 'feedback', deprecate_info=g.deprecate(redirect='az feedback', target='feedback', hide=True))
 
     with self.command_group('devops', command_type=configureOps) as g:
         g.command('configure', 'configure')

--- a/azure-devops/azext_devops/dev/team/feedback.py
+++ b/azure-devops/azext_devops/dev/team/feedback.py
@@ -5,7 +5,6 @@
 # --------------------------------------------------------------------------------------------
 
 from __future__ import print_function
-from azext_devops.dev.common.utils import open_url
 
 
 def feedback():
@@ -14,4 +13,3 @@ def feedback():
     url = 'https://aka.ms/azure-devops-cli-feedback'
     print('Thank you for taking the time to share your feedback. Please submit your feedback on the following web ' +
           'page: {url}'.format(url=url))
-    open_url(url=url)


### PR DESCRIPTION
Please make sure the code is following contribution guidelines in CONTRIBUTING.md

 - [ ] : This PR has a corresponding issue open in the Repository.
 - [ ] : Approach is signed off on the issue.

- Hide command
- Deprecate message pointing to use az feedback instead.
- Do not open the url only print the message as it used to do earlier (so that the hit count on the url comes down.)

![image](https://user-images.githubusercontent.com/11888714/67373177-cdebd980-f59c-11e9-9427-a56046e8bfe4.png)
