### PR TITLE
Re-adding optional project parameter to artifacts universal commands + unit tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
 {
     "python.testing.pytestEnabled": true,
-    "python.pythonPath": "env\\Scripts\\python.exe",
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
     "python.testing.pytestEnabled": true,
+    "python.pythonPath": "env\\Scripts\\python.exe",
 }

--- a/azure-devops/azext_devops/dev/artifacts/arguments.py
+++ b/azure-devops/azext_devops/dev/artifacts/arguments.py
@@ -3,10 +3,14 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+from knack.arguments import enum_choice_list
+
+_SCOPE_VALUES = ['project', 'organization']
 
 def load_package_arguments(self, _):
     with self.argument_context('artifacts universal') as context:
         context.argument('name', options_list=('--name', '-n'))
         context.argument('version', options_list=('--version', '-v'))
+        context.argument('scope', **enum_choice_list(_SCOPE_VALUES))
     with self.argument_context('artifacts universal publish') as context:
         context.argument('description', options_list=('--description', '-d'))

--- a/azure-devops/azext_devops/dev/artifacts/arguments.py
+++ b/azure-devops/azext_devops/dev/artifacts/arguments.py
@@ -3,9 +3,12 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+
 from knack.arguments import enum_choice_list
 
+
 _SCOPE_VALUES = ['project', 'organization']
+
 
 def load_package_arguments(self, _):
     with self.argument_context('artifacts universal') as context:

--- a/azure-devops/azext_devops/dev/artifacts/universal.py
+++ b/azure-devops/azext_devops/dev/artifacts/universal.py
@@ -14,7 +14,15 @@ from azext_devops.dev.common.external_tool import ProgressReportingExternalToolI
 logger = get_logger(__name__)
 
 
-def publish_package(feed, name, version, path, description=None, scope='organization', organization=None, project=None, detect=None):
+def publish_package(feed,
+                    name,
+                    version,
+                    path,
+                    description=None,
+                    scope='organization',
+                    organization=None,
+                    project=None,
+                    detect=None):
     """Publish a package to a feed.
     :param scope: Scope of the feed: 'project' if the feed was created in a project, and 'organization' otherwise.
     :type scope: str
@@ -48,7 +56,15 @@ def publish_package(feed, name, version, path, description=None, scope='organiza
     return artifact_tool.publish_universal(organization, project, feed, name, version, description, path)
 
 
-def download_package(feed, name, version, path, file_filter=None, scope='organization', organization=None, project=None, detect=None):
+def download_package(feed,
+                     name,
+                     version,
+                     path,
+                     file_filter=None,
+                     scope='organization',
+                     organization=None,
+                     project=None,
+                     detect=None):
     """Download a package.
     :param scope: Scope of the feed: 'project' if the feed was created in a project, and 'organization' otherwise.
     :type scope: str

--- a/azure-devops/azext_devops/dev/artifacts/universal.py
+++ b/azure-devops/azext_devops/dev/artifacts/universal.py
@@ -46,7 +46,7 @@ def publish_package(feed,
             project=project)
     else:
         if project is not None:
-            raise CLIError('--scope \'project\' is required when specifying a project in --project')
+            raise CLIError('--scope \'project\' is required when specifying a value in --project')
 
         organization = resolve_instance(
             detect=detect,
@@ -88,7 +88,7 @@ def download_package(feed,
             project=project)
     else:
         if project is not None:
-            raise CLIError('--scope \'project\' is required when specifying a project in --project')
+            raise CLIError('--scope \'project\' is required when specifying a value in --project')
 
         organization = resolve_instance(
             detect=detect,

--- a/azure-devops/azext_devops/dev/artifacts/universal.py
+++ b/azure-devops/azext_devops/dev/artifacts/universal.py
@@ -5,7 +5,8 @@
 
 import colorama
 from knack.log import get_logger
-from azext_devops.dev.common.services import resolve_instance_and_project
+from knack.util import CLIError
+from azext_devops.dev.common.services import resolve_instance, resolve_instance_and_project
 from azext_devops.dev.common.artifacttool import ArtifactToolInvoker
 from azext_devops.dev.common.artifacttool_updater import ArtifactToolUpdater
 from azext_devops.dev.common.external_tool import ProgressReportingExternalToolInvoker
@@ -13,8 +14,10 @@ from azext_devops.dev.common.external_tool import ProgressReportingExternalToolI
 logger = get_logger(__name__)
 
 
-def publish_package(feed, name, version, path, description=None, organization=None, project=None, detect=None):
+def publish_package(feed, name, version, path, description=None, scope='organization', organization=None, project=None, detect=None):
     """Publish a package to a feed.
+    :param scope: Scope of the feed: 'project' if the feed was created in a project, and 'organization' otherwise.
+    :type scope: str
     :param feed: Name or ID of the feed.
     :type feed: str
     :param name: Name of the package, e.g. 'foo-package'.
@@ -28,18 +31,27 @@ def publish_package(feed, name, version, path, description=None, organization=No
     """
     colorama.init()   # Needed for humanfriendly spinner to display correctly
 
-    organization, project = resolve_instance_and_project(
-        detect=detect,
-        organization=organization,
-        project=project,
-        project_required=False)
+    if scope == 'project':
+        organization, project = resolve_instance_and_project(
+            detect=detect,
+            organization=organization,
+            project=project)
+    else:
+        if project is not None:
+            raise CLIError('--scope \'project\' is required when specifying a project in --project')
+
+        organization = resolve_instance(
+            detect=detect,
+            organization=organization)
 
     artifact_tool = ArtifactToolInvoker(ProgressReportingExternalToolInvoker(), ArtifactToolUpdater())
     return artifact_tool.publish_universal(organization, project, feed, name, version, description, path)
 
 
-def download_package(feed, name, version, path, file_filter=None, organization=None, project=None, detect=None):
+def download_package(feed, name, version, path, file_filter=None, scope='organization', organization=None, project=None, detect=None):
     """Download a package.
+    :param scope: Scope of the feed: 'project' if the feed was created in a project, and 'organization' otherwise.
+    :type scope: str
     :param feed: Name or ID of the feed.
     :type feed: str
     :param name: Name of the package, e.g. 'foo-package'.
@@ -53,11 +65,18 @@ def download_package(feed, name, version, path, file_filter=None, organization=N
     """
     colorama.init()  # Needed for humanfriendly spinner to display correctly
 
-    organization, project = resolve_instance_and_project(
-        detect=detect,
-        organization=organization,
-        project=project,
-        project_required=False)
+    if scope == 'project':
+        organization, project = resolve_instance_and_project(
+            detect=detect,
+            organization=organization,
+            project=project)
+    else:
+        if project is not None:
+            raise CLIError('--scope \'project\' is required when specifying a project in --project')
+
+        organization = resolve_instance(
+            detect=detect,
+            organization=organization)
 
     artifact_tool = ArtifactToolInvoker(ProgressReportingExternalToolInvoker(), ArtifactToolUpdater())
     return artifact_tool.download_universal(organization, project, feed, name, version, path, file_filter)

--- a/azure-devops/azext_devops/dev/artifacts/universal.py
+++ b/azure-devops/azext_devops/dev/artifacts/universal.py
@@ -5,7 +5,7 @@
 
 import colorama
 from knack.log import get_logger
-from azext_devops.dev.common.services import resolve_instance
+from azext_devops.dev.common.services import resolve_instance_and_project
 from azext_devops.dev.common.artifacttool import ArtifactToolInvoker
 from azext_devops.dev.common.artifacttool_updater import ArtifactToolUpdater
 from azext_devops.dev.common.external_tool import ProgressReportingExternalToolInvoker
@@ -13,7 +13,7 @@ from azext_devops.dev.common.external_tool import ProgressReportingExternalToolI
 logger = get_logger(__name__)
 
 
-def publish_package(feed, name, version, path, description=None, organization=None, detect=None):
+def publish_package(feed, name, version, path, description=None, organization=None, project=None, detect=None):
     """Publish a package to a feed.
     :param feed: Name or ID of the feed.
     :type feed: str
@@ -27,12 +27,12 @@ def publish_package(feed, name, version, path, description=None, organization=No
     :type path: str
     """
     colorama.init()   # Needed for humanfriendly spinner to display correctly
-    organization = resolve_instance(detect=detect, organization=organization)
+    organization, project = resolve_instance_and_project(detect=detect, organization=organization, project=project, project_required=False)
     artifact_tool = ArtifactToolInvoker(ProgressReportingExternalToolInvoker(), ArtifactToolUpdater())
-    return artifact_tool.publish_universal(organization, feed, name, version, description, path)
+    return artifact_tool.publish_universal(organization, project, feed, name, version, description, path)
 
 
-def download_package(feed, name, version, path, file_filter=None, organization=None, detect=None):
+def download_package(feed, name, version, path, file_filter=None, organization=None, project=None, detect=None):
     """Download a package.
     :param feed: Name or ID of the feed.
     :type feed: str
@@ -46,6 +46,6 @@ def download_package(feed, name, version, path, file_filter=None, organization=N
     :type file_filter: str
     """
     colorama.init()  # Needed for humanfriendly spinner to display correctly
-    organization = resolve_instance(detect=detect, organization=organization)
+    organization, project = resolve_instance_and_project(detect=detect, organization=organization, project=project, project_required=False)
     artifact_tool = ArtifactToolInvoker(ProgressReportingExternalToolInvoker(), ArtifactToolUpdater())
-    return artifact_tool.download_universal(organization, feed, name, version, path, file_filter)
+    return artifact_tool.download_universal(organization, project, feed, name, version, path, file_filter)

--- a/azure-devops/azext_devops/dev/artifacts/universal.py
+++ b/azure-devops/azext_devops/dev/artifacts/universal.py
@@ -27,7 +27,13 @@ def publish_package(feed, name, version, path, description=None, organization=No
     :type path: str
     """
     colorama.init()   # Needed for humanfriendly spinner to display correctly
-    organization, project = resolve_instance_and_project(detect=detect, organization=organization, project=project, project_required=False)
+
+    organization, project = resolve_instance_and_project(
+        detect=detect,
+        organization=organization,
+        project=project,
+        project_required=False)
+
     artifact_tool = ArtifactToolInvoker(ProgressReportingExternalToolInvoker(), ArtifactToolUpdater())
     return artifact_tool.publish_universal(organization, project, feed, name, version, description, path)
 
@@ -46,6 +52,12 @@ def download_package(feed, name, version, path, file_filter=None, organization=N
     :type file_filter: str
     """
     colorama.init()  # Needed for humanfriendly spinner to display correctly
-    organization, project = resolve_instance_and_project(detect=detect, organization=organization, project=project, project_required=False)
+
+    organization, project = resolve_instance_and_project(
+        detect=detect,
+        organization=organization,
+        project=project,
+        project_required=False)
+
     artifact_tool = ArtifactToolInvoker(ProgressReportingExternalToolInvoker(), ArtifactToolUpdater())
     return artifact_tool.download_universal(organization, project, feed, name, version, path, file_filter)

--- a/azure-devops/azext_devops/dev/common/artifacttool.py
+++ b/azure-devops/azext_devops/dev/common/artifacttool.py
@@ -30,17 +30,24 @@ class ArtifactToolInvoker:
                 "--project", project, "--pipeline-id", run_id, "--artifact-name", artifact_name, "--path", path]
         return self.run_artifacttool(organization, args, "Uploading")
 
-    def download_universal(self, organization, feed, package_name, package_version, path, file_filter):
+    def download_universal(self, organization, project, feed, package_name, package_version, path, file_filter):
         args = ["universal", "download", "--service", organization, "--patvar", ARTIFACTTOOL_PAT_ENVKEY,
                 "--feed", feed, "--package-name", package_name, "--package-version", package_version,
                 "--path", path]
+
+        if project:
+            args.extend(["--project", project])
+
         if file_filter:
             args.extend(["--filter", file_filter])
         return self.run_artifacttool(organization, args, "Downloading")
 
-    def publish_universal(self, organization, feed, package_name, package_version, description, path):
+    def publish_universal(self, organization, project, feed, package_name, package_version, description, path):
         args = ["universal", "publish", "--service", organization, "--patvar", ARTIFACTTOOL_PAT_ENVKEY,
                 "--feed", feed, "--package-name", package_name, "--package-version", package_version, "--path", path]
+
+        if project:
+            args.extend(["--project", project])
 
         if description:
             args.extend(["--description", description])

--- a/azure-devops/azext_devops/test/artifacts/test_univeral.py
+++ b/azure-devops/azext_devops/test/artifacts/test_univeral.py
@@ -17,6 +17,7 @@ from azext_devops.dev.artifacts.universal import (publish_package,
 from azext_devops.dev.common.artifacttool import ArtifactToolInvoker
 from azext_devops.dev.common.const import ARTIFACTTOOL_PAT_ENVKEY
 from azext_devops.dev.common.services import clear_connection_cache
+from knack.util import CLIError
 
 
 
@@ -95,6 +96,17 @@ class TestUniversalPackages(unittest.TestCase):
                  '--description', self._TEST_PACKAGE_DESCRIPTION,
             ],
             'Publishing')
+
+    def test_publish_package_when_project_without_scope_then_exception(self):
+        with self.assertRaises(CLIError) as exc:
+            response = publish_package(feed = self._TEST_FEED_NAME,
+                name = self._TEST_PACKAGE_NAME,
+                version = self._TEST_PACKAGE_VERSION,
+                description = self._TEST_PACKAGE_DESCRIPTION,
+                path = self._TEST_PATH,
+                organization = self._TEST_DEVOPS_ORGANIZATION,
+                project = self._TEST_DEVOPS_PROJECT)
+        self.assertIn('--scope \'project\' is required when specifying a value in --project', str(exc.exception))
         
     def test_download_package(self):
         response = download_package(feed = self._TEST_FEED_NAME,
@@ -142,4 +154,15 @@ class TestUniversalPackages(unittest.TestCase):
                     '--filter', self._TEST_FILTER,
             ],
             'Downloading')
+
+    def test_download_package_when_project_without_scope_then_exception(self):
+        with self.assertRaises(CLIError) as exc:
+            response = download_package(feed = self._TEST_FEED_NAME,
+                name = self._TEST_PACKAGE_NAME,
+                version = self._TEST_PACKAGE_VERSION,
+                path = self._TEST_PATH,
+                file_filter= self._TEST_FILTER,
+                organization = self._TEST_DEVOPS_ORGANIZATION,
+                project = self._TEST_DEVOPS_PROJECT)
+        self.assertIn('--scope \'project\' is required when specifying a value in --project', str(exc.exception))
                 

--- a/azure-devops/azext_devops/test/artifacts/test_univeral.py
+++ b/azure-devops/azext_devops/test/artifacts/test_univeral.py
@@ -22,7 +22,10 @@ from azext_devops.dev.common.services import clear_connection_cache
 
 class TestUniversalPackages(unittest.TestCase):
 
+    _CONST_ORGANIZATION_SCOPE = 'organization'
+    _CONST_PROJECT_SCOPE = 'project'
     _TEST_DEVOPS_ORGANIZATION = 'https://someorg.visualstudio.com'
+    _TEST_DEVOPS_PROJECT = 'my-test-project'
     _TEST_PAT_TOKEN = 'somepattoken'
     _TEST_FEED_NAME = 'my-test-feed'
     _TEST_PACKAGE_NAME = 'my-test-package'
@@ -57,15 +60,40 @@ class TestUniversalPackages(unittest.TestCase):
         # assert
         self.mock_run_artifacttool.assert_called_with(self._TEST_DEVOPS_ORGANIZATION,
             [
-                'universal', 'publish', 
-                '--service', self._TEST_DEVOPS_ORGANIZATION, 
-                 '--patvar', ARTIFACTTOOL_PAT_ENVKEY, 
-                 '--feed', self._TEST_FEED_NAME, 
-                 '--package-name', self._TEST_PACKAGE_NAME, 
-                 '--package-version', self._TEST_PACKAGE_VERSION, 
-                 '--path', self._TEST_PATH, 
+                'universal', 'publish',
+                '--service', self._TEST_DEVOPS_ORGANIZATION,
+                 '--patvar', ARTIFACTTOOL_PAT_ENVKEY,
+                 '--feed', self._TEST_FEED_NAME,
+                 '--package-name', self._TEST_PACKAGE_NAME,
+                 '--package-version', self._TEST_PACKAGE_VERSION,
+                 '--path', self._TEST_PATH,
                  '--description', self._TEST_PACKAGE_DESCRIPTION
-            ], 
+            ],
+            'Publishing')
+
+    def test_publish_package_with_project(self):
+        response = publish_package(feed = self._TEST_FEED_NAME,
+            name = self._TEST_PACKAGE_NAME,
+            version = self._TEST_PACKAGE_VERSION,
+            description = self._TEST_PACKAGE_DESCRIPTION,
+            path = self._TEST_PATH,
+            organization = self._TEST_DEVOPS_ORGANIZATION,
+            project = self._TEST_DEVOPS_PROJECT,
+            scope = self._CONST_PROJECT_SCOPE)
+
+        # assert
+        self.mock_run_artifacttool.assert_called_with(self._TEST_DEVOPS_ORGANIZATION,
+            [
+                'universal', 'publish',
+                '--service', self._TEST_DEVOPS_ORGANIZATION,
+                 '--patvar', ARTIFACTTOOL_PAT_ENVKEY,
+                 '--feed', self._TEST_FEED_NAME,
+                 '--package-name', self._TEST_PACKAGE_NAME,
+                 '--package-version', self._TEST_PACKAGE_VERSION,
+                 '--path', self._TEST_PATH,
+                 '--project', self._TEST_DEVOPS_PROJECT,
+                 '--description', self._TEST_PACKAGE_DESCRIPTION,
+            ],
             'Publishing')
         
     def test_download_package(self):
@@ -79,14 +107,39 @@ class TestUniversalPackages(unittest.TestCase):
         # assert
         self.mock_run_artifacttool.assert_called_with(self._TEST_DEVOPS_ORGANIZATION,
             [
-                'universal', 'download', 
-                '--service', self._TEST_DEVOPS_ORGANIZATION, 
-                    '--patvar', ARTIFACTTOOL_PAT_ENVKEY, 
-                    '--feed', self._TEST_FEED_NAME, 
-                    '--package-name', self._TEST_PACKAGE_NAME, 
-                    '--package-version', self._TEST_PACKAGE_VERSION, 
-                    '--path', self._TEST_PATH, 
+                'universal', 'download',
+                '--service', self._TEST_DEVOPS_ORGANIZATION,
+                    '--patvar', ARTIFACTTOOL_PAT_ENVKEY,
+                    '--feed', self._TEST_FEED_NAME,
+                    '--package-name', self._TEST_PACKAGE_NAME,
+                    '--package-version', self._TEST_PACKAGE_VERSION,
+                    '--path', self._TEST_PATH,
                     '--filter', self._TEST_FILTER,
-            ], 
+            ],
+            'Downloading')
+
+    def test_download_package_with_project(self):
+        response = download_package(feed = self._TEST_FEED_NAME,
+            name = self._TEST_PACKAGE_NAME,
+            version = self._TEST_PACKAGE_VERSION,
+            path = self._TEST_PATH,
+            file_filter= self._TEST_FILTER,
+            organization = self._TEST_DEVOPS_ORGANIZATION,
+            project = self._TEST_DEVOPS_PROJECT,
+            scope = self._CONST_PROJECT_SCOPE)
+
+        # assert
+        self.mock_run_artifacttool.assert_called_with(self._TEST_DEVOPS_ORGANIZATION,
+            [
+                'universal', 'download',
+                '--service', self._TEST_DEVOPS_ORGANIZATION,
+                    '--patvar', ARTIFACTTOOL_PAT_ENVKEY,
+                    '--feed', self._TEST_FEED_NAME,
+                    '--package-name', self._TEST_PACKAGE_NAME,
+                    '--package-version', self._TEST_PACKAGE_VERSION,
+                    '--path', self._TEST_PATH,
+                    '--project', self._TEST_DEVOPS_PROJECT,
+                    '--filter', self._TEST_FILTER,
+            ],
             'Downloading')
                 


### PR DESCRIPTION
The required change in ArtifactTool has now been released.

This adds unit tests missing in #835, so contains the changes in #835 + unit tests.  Otherwise, this PR has the same changes as #785 , which was reverted in #789 since the change in ArtifactTool wasn't ready at the time.

