### PR TITLE
Ideally we should be testing with latest version of python

### DIFF
--- a/.azure-pipelines/azure-pipelines-create-release.yml
+++ b/.azure-pipelines/azure-pipelines-create-release.yml
@@ -17,7 +17,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.7'
+      versionSpec: '3.x'
       architecture: 'x64'
 
   - template: templates/setup-ci-machine.yml
@@ -31,7 +31,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.7'
+      versionSpec: '3.x'
       architecture: 'x64'
 
   - template: templates/setup-ci-machine.yml
@@ -46,7 +46,7 @@ jobs:
   steps:
   - template: templates/run-tests.yml
     parameters:
-      pythonVersion: '3.7'
+      pythonVersion: '3.x'
 
   - script: 'pip install .'
     displayName: 'Install the whl locally'

--- a/.azure-pipelines/azure-pipelines-live-test-run.yml
+++ b/.azure-pipelines/azure-pipelines-live-test-run.yml
@@ -23,7 +23,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.7'
+      versionSpec: '3.x'
       architecture: 'x64'
 
   - template: templates/setup-ci-machine.yml
@@ -37,7 +37,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.7'
+      versionSpec: '3.x'
       architecture: 'x64'
 
   - template: templates/setup-ci-machine.yml

--- a/.azure-pipelines/azure-pipelines-merge.yml
+++ b/.azure-pipelines/azure-pipelines-merge.yml
@@ -17,7 +17,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.7'
+      versionSpec: '3.x'
       architecture: 'x64'
 
   - template: templates/setup-ci-machine.yml
@@ -31,7 +31,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.7'
+      versionSpec: '3.x'
       architecture: 'x64'
 
   - template: templates/setup-ci-machine.yml
@@ -51,7 +51,7 @@ jobs:
   
   - template: templates/run-tests.yml
     parameters:
-      pythonVersion: '3.7'
+      pythonVersion: '3.x'
 
   - script: 'python setup.py sdist bdist_wheel'
     displayName: 'Build wheel for Azure DevOps CLI extension'
@@ -78,7 +78,7 @@ jobs:
       Python36:
         python.version: '3.6.x'
       Python37:
-        python.version: '3.7'
+        python.version: '3.x'
     maxParallel: 3
 
   steps:
@@ -96,7 +96,7 @@ jobs:
   steps:
   - template: templates/run-tests.yml
     parameters:
-      pythonVersion: '3.7'
+      pythonVersion: '3.x'
 
 - job: 'Run_Test_Mac_Azure_CLI_Released_Version'
   dependsOn : Build_Publish_Azure_CLI_Test_SDK
@@ -106,7 +106,7 @@ jobs:
   steps:
   - template: templates/run-tests.yml
     parameters:
-      pythonVersion: '3.7'
+      pythonVersion: '3.x'
       runWithAzureCliReleased: 'true'
 
 - job: 'Code_Coverage'
@@ -117,7 +117,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.7'
+      versionSpec: '3.x'
       architecture: 'x64'
 
   - template: templates/install-azure-cli-edge.yml
@@ -154,7 +154,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.7'
+      versionSpec: '3.x'
       architecture: 'x64'
 
   - template: templates/install-azure-cli-edge.yml
@@ -179,7 +179,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.7'
+      versionSpec: '3.x'
       architecture: 'x64'
 
   - template: templates/install-azure-cli-edge.yml
@@ -216,7 +216,7 @@ jobs:
 
   - template: templates/run-tests.yml
     parameters:
-      pythonVersion: '3.7'
+      pythonVersion: '3.x'
       runOnlyRecordedTests: 'true'
 
 - job: 'Check_Back_Compat_Arguments'
@@ -226,7 +226,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.7'
+      versionSpec: '3.x'
       architecture: 'x64'
 
   - template: templates/setup-ci-machine.yml

--- a/.azure-pipelines/azure-pipelines-pr.yml
+++ b/.azure-pipelines/azure-pipelines-pr.yml
@@ -17,7 +17,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.7'
+      versionSpec: '3.x'
       architecture: 'x64'
 
   - template: templates/setup-ci-machine.yml
@@ -31,7 +31,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.7'
+      versionSpec: '3.x'
       architecture: 'x64'
 
   - template: templates/setup-ci-machine.yml
@@ -49,7 +49,7 @@ jobs:
       Python36:
         python.version: '3.6.x'
       Python37:
-        python.version: '3.7'
+        python.version: '3.x'
     maxParallel: 3
 
   steps:
@@ -67,7 +67,7 @@ jobs:
   steps:
   - template: templates/run-tests.yml
     parameters:
-      pythonVersion: '3.7'
+      pythonVersion: '3.x'
 
 - job: 'Run_Test_Mac_Azure_CLI_Released_Version'
   dependsOn : Build_Publish_Azure_CLI_Test_SDK
@@ -77,7 +77,7 @@ jobs:
   steps:
   - template: templates/run-tests.yml
     parameters:
-      pythonVersion: '3.7'
+      pythonVersion: '3.x'
       runWithAzureCliReleased: 'true'
 
 - job: 'Run_Test_Windows'
@@ -93,7 +93,7 @@ jobs:
 
   - template: templates/run-tests.yml
     parameters:
-      pythonVersion: '3.7'
+      pythonVersion: '3.x'
 
 - job: 'Code_Coverage'
   dependsOn: 'Build_Publish_Azure_CLI_Test_SDK'
@@ -103,7 +103,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.7'
+      versionSpec: '3.x'
       architecture: 'x64'
 
   - template: templates/install-azure-cli-edge.yml
@@ -140,7 +140,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.7'
+      versionSpec: '3.x'
       architecture: 'x64'
 
   - template: templates/install-azure-cli-edge.yml
@@ -165,7 +165,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.7'
+      versionSpec: '3.x'
       architecture: 'x64'
 
   - template: templates/install-azure-cli-edge.yml
@@ -202,7 +202,7 @@ jobs:
 
   - template: templates/run-tests.yml
     parameters:
-      pythonVersion: '3.7'
+      pythonVersion: '3.x'
       runOnlyRecordedTests: 'true'
 
 - job: 'Check_Back_Compat_Arguments'
@@ -212,7 +212,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.7'
+      versionSpec: '3.x'
       architecture: 'x64'
 
   - template: templates/setup-ci-machine.yml

--- a/.azure-pipelines/azure-pipelines-released-version.yml
+++ b/.azure-pipelines/azure-pipelines-released-version.yml
@@ -22,7 +22,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.7'
+      versionSpec: '3.x'
       architecture: 'x64'
 
   - template: templates/setup-ci-machine.yml
@@ -37,7 +37,7 @@ jobs:
   steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '3.7'
+        versionSpec: '3.x'
         architecture: 'x64'
 
     - template: templates/install-azure-cli-edge.yml

--- a/.azure-pipelines/templates/install-azure-cli-edge.yml
+++ b/.azure-pipelines/templates/install-azure-cli-edge.yml
@@ -8,6 +8,9 @@ steps:
   - script: 'az --version'
     displayName: 'Display az version before update'
 
+  - script: 'pip uninstall azure-cli -y'
+    displayName: 'Remove Azure CLI'
+
   - script: 'pip install --pre azure-cli --extra-index-url https://azurecliprod.blob.core.windows.net/edge --upgrade-strategy eager'
     displayName: 'Install Azure CLI Edge'
 

--- a/.azure-pipelines/templates/install-azure-cli-edge.yml
+++ b/.azure-pipelines/templates/install-azure-cli-edge.yml
@@ -1,3 +1,9 @@
 steps:
+  - script: 'az --version'
+    displayName: 'Display az version before update'
+
   - script: 'pip install azure-cli'
     displayName: 'Install Azure CLI Released'
+
+  - script: 'az --version'
+    displayName: 'Display az version after update'

--- a/.azure-pipelines/templates/install-azure-cli-edge.yml
+++ b/.azure-pipelines/templates/install-azure-cli-edge.yml
@@ -1,3 +1,3 @@
 steps:
-  - script: 'pip install --pre azure-cli --extra-index-url https://azurecliprod.blob.core.windows.net/edge'
-    displayName: 'Install Azure CLI Edge'
+  - script: 'pip install azure-cli'
+    displayName: 'Install Azure CLI Released'

--- a/.azure-pipelines/templates/install-azure-cli-edge.yml
+++ b/.azure-pipelines/templates/install-azure-cli-edge.yml
@@ -5,8 +5,8 @@ steps:
   - script: 'az --version'
     displayName: 'Display az version before update'
 
-  - script: 'pip install azure-cli'
-    displayName: 'Install Azure CLI Released'
+  - script: 'pip install --pre azure-cli --extra-index-url https://azurecliprod.blob.core.windows.net/edge'
+    displayName: 'Install Azure CLI Edge'
 
   - script: 'python --version'
     displayName: 'Display Python version'

--- a/.azure-pipelines/templates/install-azure-cli-edge.yml
+++ b/.azure-pipelines/templates/install-azure-cli-edge.yml
@@ -1,9 +1,15 @@
 steps:
+  - script: 'python --version'
+    displayName: 'Display Python version'
+
   - script: 'az --version'
     displayName: 'Display az version before update'
 
   - script: 'pip install azure-cli'
     displayName: 'Install Azure CLI Released'
+
+  - script: 'python --version'
+    displayName: 'Display Python version'
 
   - script: 'az --version'
     displayName: 'Display az version after update'

--- a/.azure-pipelines/templates/install-azure-cli-edge.yml
+++ b/.azure-pipelines/templates/install-azure-cli-edge.yml
@@ -1,11 +1,14 @@
 steps:
+  - script: 'python -m pip install --upgrade pip'
+    displayName: 'Upgrade pip'
+
   - script: 'python --version'
     displayName: 'Display Python version'
 
   - script: 'az --version'
     displayName: 'Display az version before update'
 
-  - script: 'pip install --pre azure-cli --extra-index-url https://azurecliprod.blob.core.windows.net/edge'
+  - script: 'pip install --pre azure-cli --extra-index-url https://azurecliprod.blob.core.windows.net/edge --upgrade-strategy eager'
     displayName: 'Install Azure CLI Edge'
 
   - script: 'python --version'

--- a/doc/samples.md
+++ b/doc/samples.md
@@ -182,7 +182,7 @@ steps:
   # Updating the python version available on the linux agent
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.7'
+      versionSpec: '3.x'
       architecture: 'x64'
 
   # Updating pip to latest
@@ -214,7 +214,7 @@ steps:
   # Updating the python version available on the linux agent
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.7'
+      versionSpec: '3.x'
       architecture: 'x64'
 
   # Updating pip to latest which is required by the Azure DevOps extension


### PR DESCRIPTION
We should merge this as soon as builds turn green for this build
Revert "use python 3.7 instead of latest because 3.8 has issues (#863)"

This reverts commit a98f526d9e170bce24d07b4888faae0b0086eaaf.

Please make sure the code is following contribution guidelines in CONTRIBUTING.md

 - [ ] : This PR has a corresponding issue open in the Repository.
 - [ ] : Approach is signed off on the issue.
