### PR TITLE
Fallback to file storage when keyring is not working

### DIFF
--- a/azure-devops/azext_devops/dev/common/credential_store.py
+++ b/azure-devops/azext_devops/dev/common/credential_store.py
@@ -55,6 +55,7 @@ class CredentialStore:
             import keyring
         except ImportError:
             return None
+        token = None
         try:
             token = keyring.get_password(key, self._USERNAME)
         except Exception as ex:  # pylint: disable=broad-except

--- a/azure-devops/azext_devops/dev/common/credential_store.py
+++ b/azure-devops/azext_devops/dev/common/credential_store.py
@@ -37,9 +37,9 @@ class CredentialStore:
         except Exception as ex:  # pylint: disable=broad-except
             # store credentials in azuredevops config directory if keyring is missing or malfunctioning
             if sys.platform.startswith(self._LINUX_PLATFORM):
-                logger.warning('Failed to store PAT using keyring; falling back to file storage.\
-                    You can clear the stored credential by running az devops logout.\
-                    Refer https://aka.ms/azure-devops-cli-auth to know more on sign in with PAT.')
+                logger.warning('Failed to store PAT using keyring; falling back to file storage.')
+                logger.warning('You can clear the stored credential by running az devops logout.')
+                logger.warning('Refer https://aka.ms/azure-devops-cli-auth to know more on sign in with PAT.')
                 logger.debug('Keyring failed. ERROR :%s', ex)
                 logger.debug('Storing credentials in the file: %s', self._PAT_FILE)
                 creds_list = self._get_credentials_list()
@@ -50,7 +50,6 @@ class CredentialStore:
                 self._commit_change(creds_list)
             else:
                 raise CLIError(ex)
-
 
     def get_password(self, key):
         try:
@@ -65,10 +64,10 @@ class CredentialStore:
                 token = None
             else:
                 raise CLIError(ex)
-        if token is None:
+        # look for credential in file too for linux if token is None
+        if token is None and sys.platform.startswith(self._LINUX_PLATFORM):
             token = self.get_PAT_from_file(key)
         return token
-
 
     def clear_password(self, key):
         try:
@@ -78,6 +77,8 @@ class CredentialStore:
             self._initialize_keyring()
             import keyring
         if sys.platform.startswith(self._LINUX_PLATFORM):
+            keyring_token = None
+            file_token = None
             try:
                 keyring_token = keyring.get_password(key, self._USERNAME)
                 if keyring_token:
@@ -88,20 +89,19 @@ class CredentialStore:
                 if file_token:
                     self.delete_PAT_from_file(key)
             if(keyring_token is None and file_token is None):
-                raise CLIError('The credential was not found')
+                raise CLIError(self._CRDENTIAL_NOT_FOUND_MSG)
         else:
             try:
                 keyring.delete_password(key, self._USERNAME)
             except keyring.errors.PasswordDeleteError:
-                raise CLIError('The credential was not found')
+                raise CLIError(self._CRDENTIAL_NOT_FOUND_MSG)
             except RuntimeError as ex:  # pylint: disable=broad-except
                 raise CLIError(ex)
 
-
     def get_PAT_from_file(self, key):
         ensure_dir(AZ_DEVOPS_GLOBAL_CONFIG_DIR)
-        logger.debug('Keyring not configured properly or package not found.\
-                        Looking for credentials in the file: %s', self._PAT_FILE)
+        logger.debug('Keyring not configured properly or package not found.'
+                'Looking for credentials with key:%s in the file: %s', key, self._PAT_FILE)
         creds_list = self._get_credentials_list()
         try:
             return creds_list.get(key, self._USERNAME)
@@ -109,11 +109,11 @@ class CredentialStore:
             return None
 
     def delete_PAT_from_file(self, key):
-        logger.debug('Keyring not configured properly or package not found.\
-                      Looking for credentials in the file: %s', self._PAT_FILE)
+        logger.debug('Keyring not configured properly or package not found.'
+                     'Looking for credentials with key:%s in the file: %s', key, self._PAT_FILE)
         creds_list = self._get_credentials_list()
         if key not in creds_list.sections():
-            raise CLIError('The credential was not found')
+            raise CLIError(self._CRDENTIAL_NOT_FOUND_MSG)
         creds_list.remove_section(key)
         self._commit_change(creds_list)
 
@@ -157,3 +157,4 @@ class CredentialStore:
     _USERNAME = 'Personal Access Token'
     _LINUX_PLATFORM = 'linux'
     _PAT_FILE = os.path.join(AZ_DEVOPS_GLOBAL_CONFIG_DIR, 'personalAccessTokens')
+    _CRDENTIAL_NOT_FOUND_MSG = 'The credential was not found'

--- a/azure-devops/azext_devops/dev/common/credential_store.py
+++ b/azure-devops/azext_devops/dev/common/credential_store.py
@@ -18,7 +18,6 @@ class CredentialStore:
     def __init__(self):
         self._initialize_keyring()
 
-
     def set_password(self, key, token):
         try:
             import keyring
@@ -101,7 +100,7 @@ class CredentialStore:
     def get_PAT_from_file(self, key):
         ensure_dir(AZ_DEVOPS_GLOBAL_CONFIG_DIR)
         logger.debug('Keyring not configured properly or package not found.'
-                'Looking for credentials with key:%s in the file: %s', key, self._PAT_FILE)
+                     'Looking for credentials with key:%s in the file: %s', key, self._PAT_FILE)
         creds_list = self._get_credentials_list()
         try:
             return creds_list.get(key, self._USERNAME)


### PR DESCRIPTION
Please make sure the code is following contribution guidelines in CONTRIBUTING.md

 - [ ] : This PR has a corresponding issue open in the Repository.
 - [ ] : Approach is signed off on the issue.

Fixes #762 

If keyring is not configured properly, we will store the credentials in file (in user home directory) with a warning


![KeyringFailedSnap](https://user-images.githubusercontent.com/43136080/68744930-ab893100-061b-11ea-829f-0c5f535dbbfd.PNG)
