### PR TITLE
Retrying os rename on failure and more logging

### DIFF
--- a/azure-devops/azext_devops/dev/common/artifacttool_updater.py
+++ b/azure-devops/azext_devops/dev/common/artifacttool_updater.py
@@ -137,7 +137,7 @@ def _update_artifacttool(uri, release_id):
                     try:
                         os.rename(release_temp_dir, release_dir)
                         break
-                    except BaseException as ex:
+                    except BaseException as ex: # pylint: disable=broad-except
                         logger.debug(
                             "An error occurred while renaming the Universal Packages tooling: %s. Retrying...", ex)
                         time.sleep(1)

--- a/azure-devops/azext_devops/dev/common/artifacttool_updater.py
+++ b/azure-devops/azext_devops/dev/common/artifacttool_updater.py
@@ -126,7 +126,9 @@ def _update_artifacttool(uri, release_id):
             # Move the release into the real releases location
             release_dir = _compute_release_dir(release_id)
             if os.path.exists(release_dir):
-                logger.info("The Universal Packages tool already exists at the location %s. Skipping download.", release_dir)
+                logger.info(
+                    "The Universal Packages tool already exists at the location %s. Skipping download.", 
+                    release_dir)
             else:
                 logger.debug("Moving downloaded ArtifactTool from %s to %s", release_temp_dir, release_dir)
                 # number of times to retry
@@ -136,7 +138,8 @@ def _update_artifacttool(uri, release_id):
                         os.rename(release_temp_dir, release_dir)
                         break
                     except BaseException as ex:
-                        logger.debug("An error occurred while renaming the Universal Packages tooling: %s. Retrying...", ex)
+                        logger.debug(
+                            "An error occurred while renaming the Universal Packages tooling: %s. Retrying...", ex)
                         time.sleep(1)
                 else:
                     os.rename(release_temp_dir, release_dir)

--- a/azure-devops/azext_devops/dev/common/artifacttool_updater.py
+++ b/azure-devops/azext_devops/dev/common/artifacttool_updater.py
@@ -137,7 +137,7 @@ def _update_artifacttool(uri, release_id):
                     try:
                         os.rename(release_temp_dir, release_dir)
                         break
-                    except BaseException as ex: # pylint: disable=broad-except
+                    except BaseException as ex:  # pylint: disable=broad-except
                         logger.debug(
                             "An error occurred while renaming the Universal Packages tooling: %s. Retrying...", ex)
                         time.sleep(1)

--- a/azure-devops/azext_devops/dev/common/artifacttool_updater.py
+++ b/azure-devops/azext_devops/dev/common/artifacttool_updater.py
@@ -126,7 +126,7 @@ def _update_artifacttool(uri, release_id):
             # Move the release into the real releases location
             release_dir = _compute_release_dir(release_id)
             if os.path.exists(release_dir):
-                logger.info(
+                logger.warning(
                     "The Universal Packages tool already exists at the location %s. Skipping download.",
                     release_dir)
             else:

--- a/azure-devops/azext_devops/dev/common/artifacttool_updater.py
+++ b/azure-devops/azext_devops/dev/common/artifacttool_updater.py
@@ -127,7 +127,7 @@ def _update_artifacttool(uri, release_id):
             release_dir = _compute_release_dir(release_id)
             if os.path.exists(release_dir):
                 logger.info(
-                    "The Universal Packages tool already exists at the location %s. Skipping download.", 
+                    "The Universal Packages tool already exists at the location %s. Skipping download.",
                     release_dir)
             else:
                 logger.debug("Moving downloaded ArtifactTool from %s to %s", release_temp_dir, release_dir)


### PR DESCRIPTION
Please make sure the code is following contribution guidelines in CONTRIBUTING.md

 - [ Issue #776 ] : This PR has a corresponding issue open in the Repository.
 - [x] : Approach is signed off on the issue.

This PR is adding more logging and retry around os.rename which is failing for some customers because some other process is locking the file(may be an antivirus). There shouldn't be any retry in case of success.