### PR TITLE
Do not add None to sys.path

### DIFF
--- a/azure-devops/azext_devops/test/conftest.py
+++ b/azure-devops/azext_devops/test/conftest.py
@@ -9,4 +9,6 @@ from azure.cli.core.extension import get_extension_path
 # Make sure that the extension install directory is on sys.path so that dependencies can be found.
 
 extensionPath = get_extension_path('azure-devops')
-sys.path.append(extensionPath)
+# Adding None to sys.path breaks numerous libraries, including pkg_resources
+if extensionPath is not None:
+    sys.path.append(extensionPath)

--- a/scripts/backCompatChecker.py
+++ b/scripts/backCompatChecker.py
@@ -75,7 +75,9 @@ import sys
 from azure.cli.core.extension import get_extension_path
 # Make sure that the extension install directory is on sys.path so that dependencies can be found.
 extensionPath = get_extension_path('azure-devops')
-sys.path.append(extensionPath)
+# Adding None to sys.path breaks numerous libraries, including pkg_resources
+if extensionPath is not None:
+    sys.path.append(extensionPath)
 
 # loading commands from code
 from azure.cli.core.mock import DummyCli


### PR DESCRIPTION
In some cases azure.cli.core.extension.get_extension_path() can
return None. Do not add it to sys.path, as it breaks many
standard Python libraries, including pkg_resources:

$ python3 -m pytest --collect-only --assert plain
<...>
ERROR collecting tests/test_adminBannerTest.py

/usr/lib/python3.8/pkgutil.py:415: in get_importer
    importer = sys.path_importer_cache[path_item]
E   KeyError: None

During handling of the above exception, another exception occurred:
/usr/lib/python3/dist-packages/py/_path/local.py:701: in pyimport
    __import__(modname)
tests/__init__.py:7: in <module>
    pkg_resources.declare_namespace(__name__)
/usr/lib/python3/dist-packages/pkg_resources/__init__.py:2290: in declare_namespace
    _handle_ns(packageName, path_item)
/usr/lib/python3/dist-packages/pkg_resources/__init__.py:2196: in _handle_ns
    importer = get_importer(path_item)
/usr/lib/python3.8/pkgutil.py:419: in get_importer
    importer = path_hook(path_item)
<frozen zipimport>:66: in __init__
    ???
/usr/lib/python3.8/os.py:818: in fsdecode
    filename = fspath(filename)  # Does type-checking of .
E   TypeError: expected str, bytes or os.PathLike object, not NoneType

Fixes https://github.com/Azure/azure-devops-cli-extension/issues/1029

Please make sure the code is following contribution guidelines in CONTRIBUTING.md

 - [X] : This PR has a corresponding issue open in the Repository.
 - [ ] : Approach is signed off on the issue.
