### PR TITLE
1797650: Remove '?view=azure-cli-latest' syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The Azure DevOps Extension for Azure CLI adds Pipelines, Boards, Repos, Artifact
     If the CLI can open your default browser, it will do so and load a sign-in page. Otherwise, you need to open a
     browser page and follow the instructions on the command line to enter an authorization code after navigating to
     [https://aka.ms/devicelogin](https://aka.ms/devicelogin) in your browser. For more information, see the
-    [Azure CLI login page](https://docs.microsoft.com/cli/azure/authenticate-azure-cli?view=azure-cli-latest).
+    [Azure CLI login page](https://docs.microsoft.com/cli/azure/authenticate-azure-cli).
 
 See the [Get started guide](https://docs.microsoft.com/azure/devops/cli/get-started?view=azure-devops) for detailed setup instructions.
 
@@ -63,7 +63,7 @@ Commands:
 
 - Checkout the CLI docs at [docs.microsoft.com - Azure DevOps CLI](https://docs.microsoft.com/azure/devops/cli/).
 - Check out other examples in the [How-to guides](https://docs.microsoft.com/azure/devops/cli/?view=azure-devops#how-to-guides) section.
-- You can view the various commands and its usage here - [docs.microsoft.com - Azure DevOps Extension Reference](https://docs.microsoft.com/cli/azure/ext/azure-devops/?view=azure-cli-latest)
+- You can view the various commands and its usage here - [docs.microsoft.com - Azure DevOps Extension Reference](https://docs.microsoft.com/cli/azure/ext/azure-devops)
 
 ## Contribute
 

--- a/doc/command_mapping.md
+++ b/doc/command_mapping.md
@@ -1,6 +1,6 @@
 # Command Mapping
 
-> Updated till azure-devops extension version 0.13.0. This file is no longer maintained. Please check latest azure-devops [command reference](https://docs.microsoft.com/en-us/cli/azure/ext/azure-devops/?view=azure-cli-latest) for command availability.
+> Updated till azure-devops extension version 0.13.0. This file is no longer maintained. Please check latest azure-devops [command reference](https://docs.microsoft.com/en-us/cli/azure/ext/azure-devops) for command availability.
 
 The following table provides the mapping of commands from VSTS CLI to Azure DevOps Extension.
 

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -7,7 +7,7 @@ Now that you have successfully installed the Azure CLI and added the Azure DevOp
 Before you can work with Azure DevOps, you need to log in using the `az login` command.
 
 If the CLI can open your default browser, it will do so and load a sign-in page.
-Otherwise, you need to open a browser page and follow the instructions on the command line to enter an authorization code after navigating to [https://aka.ms/devicelogin](https://aka.ms/devicelogin) in your browser. For more information, see the [Azure CLI login page](https://docs.microsoft.com/cli/azure/authenticate-azure-cli?view=azure-cli-latest).
+Otherwise, you need to open a browser page and follow the instructions on the command line to enter an authorization code after navigating to [https://aka.ms/devicelogin](https://aka.ms/devicelogin) in your browser. For more information, see the [Azure CLI login page](https://docs.microsoft.com/cli/azure/authenticate-azure-cli).
 
 You can also [log in via Azure DevOps Personal Access Token (PAT)](samples.md#log-in-via-azure-devops-personal-access-token-pat)
 

--- a/doc/samples.md
+++ b/doc/samples.md
@@ -77,7 +77,7 @@ git pr create --target-branch {branch\_name}
 
 ## Configure output formats
 
-The output formats are inherited from Azure CLI. The Azure CLI uses JSON as its default output option, but offers various ways for you to format the output of any command.  Refer [Set the default output format](https://docs.microsoft.com/cli/azure/format-output-azure-cli?view=azure-cli-latest#set-the-default-output-format) guide to update default output format.
+The output formats are inherited from Azure CLI. The Azure CLI uses JSON as its default output option, but offers various ways for you to format the output of any command.  Refer [Set the default output format](https://docs.microsoft.com/cli/azure/format-output-azure-cli#set-the-default-output-format) guide to update default output format.
 
 ## Query output
 
@@ -326,7 +326,7 @@ You can create and manage YAML based multi stage Azure Pipelines using the `az p
 
 - An Azure Devops organization. If you don't have one, you can [create one for free](https://docs.microsoft.com/en-us/azure/devops/pipelines/get-started/pipelines-sign-up?view=azure-devops). If your team already has one, then make sure you're an administrator of the Azure DevOps project that you want to use.
 
-- [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest) along with the [azure-devops extension](../getting_started.md) added.
+- [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) along with the [azure-devops extension](../getting_started.md) added.
 
 - You can use Azure Pipelines to build an app written in any language. For this quickstart, we will use Java. To get started, fork the following repository into your GitHub account.
 


### PR DESCRIPTION
No code changes. Part of an effort to remove unnecessary versioning link syntax.

See user story [1797650](https://dev.azure.com/mseng/TechnicalContent/_workitems/edit/1797650) for more information.