### PR TITLE
feat(boards): Allow setting remote related and other WI URL relations directly

### DIFF
--- a/azure-devops/azext_devops/dev/boards/arguments.py
+++ b/azure-devops/azext_devops/dev/boards/arguments.py
@@ -36,6 +36,10 @@ def load_work_arguments(self, _):
         context.argument('target_id', help='ID(s) of work-items to create relation with. \
                          Multiple values can be passed comma separated. Example: 1,2 ')
 
+    with self.argument_context('boards work-item relation add-url') as context:
+        context.argument('relation_type', help='Relation type to create. Example: "Remote Related" ')
+        context.argument('url', help='Target URL')
+
     with self.argument_context('boards work-item relation remove') as context:
         context.argument('relation_type', help='Relation type to remove. Example: parent, child ')
         context.argument('target_id', help='ID(s) of work-items to remove relation from. \

--- a/azure-devops/azext_devops/dev/boards/commands.py
+++ b/azure-devops/azext_devops/dev/boards/commands.py
@@ -58,6 +58,7 @@ def load_work_commands(self, _):
         g.command('relation list-type', 'get_relation_types_show',
                   table_transformer=transform_work_item_relation_type_table_output)
         g.command('relation add', 'add_relation', table_transformer=transform_work_item_relations)
+        g.command('relation add-url', 'add_relation_url', table_transformer=transform_work_item_relations)
         g.command('relation remove', 'remove_relation', table_transformer=transform_work_item_relations,
                   confirmation='Are you sure you want to remove this relation(s)?')
         g.command('relation show', 'show_work_item', table_transformer=transform_work_item_relations)


### PR DESCRIPTION
The `boards work-item add relation` command requires looking up related
work items by ID before adding their relation URL. This does not support
relationships such as 'Remote Related', where we cannot look up remote
work item id's.

To support the 'Remote Related' scenario (or scenarios involving non-work
item URLs, as in https://docs.microsoft.com/en-us/rest/api/azure/devops/wit/work%20items/update?view=azure-devops-rest-6.0#add-a-hyperlink), we add a new command, `add-url`,
which bypasses the work item id lookup, and sets the relation URL directly.

Please make sure the code is following contribution guidelines in CONTRIBUTING.md

 - [x] : This PR has a corresponding issue open in the Repository: #1109 
 - [ ] : Approach is signed off on the issue.
