### PR TITLE
Add clarity that PAT has to be passed on StdIn

### DIFF
--- a/azure-devops/azext_devops/dev/team/credentials.py
+++ b/azure-devops/azext_devops/dev/team/credentials.py
@@ -19,7 +19,9 @@ logger = get_logger(__name__)
 
 
 def credential_set(organization=None):
-    """Set the credential (PAT) to use for a particular organization.
+    """If console is present will prompt for the credential (PAT) to use for a particular organization.
+    If no console is present creential must be passed on StdIn.
+    
     Refer https://aka.ms/azure-devops-cli-auth for more information on providing PAT as input.
     """
     token = _get_pat_token()


### PR DESCRIPTION
Add clarity that PAT can only be passed on StdIn when console(tty) isn't present

Please make sure the code is following contribution guidelines in CONTRIBUTING.md

 - [ ] : This PR has a corresponding issue open in the Repository.
 - [ ] : Approach is signed off on the issue.
