### PR TITLE
Duplicate reviewers email ids discarded

### DIFF
--- a/azure-devops/azext_devops/dev/repos/pull_request.py
+++ b/azure-devops/azext_devops/dev/repos/pull_request.py
@@ -170,7 +170,8 @@ def create_pull_request(project=None, repository=None, source_branch=None, targe
     if pr.source_ref_name == pr.target_ref_name:
         raise CLIError('The source branch, "{}", can not be the same as the target branch.'.format
                        (pr.source_ref_name))
-    reviewers = list(set(x.lower() for x in reviewers))
+    if reviewers is not None
+        reviewers = list(set(x.lower() for x in reviewers))
     pr.reviewers = _resolve_reviewers_as_refs(reviewers, organization)
     if work_items is not None and work_items:
         resolved_work_items = []

--- a/azure-devops/azext_devops/dev/repos/pull_request.py
+++ b/azure-devops/azext_devops/dev/repos/pull_request.py
@@ -170,7 +170,7 @@ def create_pull_request(project=None, repository=None, source_branch=None, targe
     if pr.source_ref_name == pr.target_ref_name:
         raise CLIError('The source branch, "{}", can not be the same as the target branch.'.format
                        (pr.source_ref_name))
-    if reviewers is not None
+    if reviewers is not None:
         reviewers = list(set(x.lower() for x in reviewers))
     pr.reviewers = _resolve_reviewers_as_refs(reviewers, organization)
     if work_items is not None and work_items:

--- a/azure-devops/azext_devops/dev/repos/pull_request.py
+++ b/azure-devops/azext_devops/dev/repos/pull_request.py
@@ -170,6 +170,7 @@ def create_pull_request(project=None, repository=None, source_branch=None, targe
     if pr.source_ref_name == pr.target_ref_name:
         raise CLIError('The source branch, "{}", can not be the same as the target branch.'.format
                        (pr.source_ref_name))
+    reviewers = list(set(x.lower() for x in reviewers))
     pr.reviewers = _resolve_reviewers_as_refs(reviewers, organization)
     if work_items is not None and work_items:
         resolved_work_items = []

--- a/azure-devops/azext_devops/test/repos/test_pull_request.py
+++ b/azure-devops/azext_devops/test/repos/test_pull_request.py
@@ -161,6 +161,7 @@ class TestPullRequestMethods(AuthenticatedTests):
         self.mock_update_PR.assert_not_called()
         assert len(self.mock_resolve_reviewers_as_refs.call_args_list) == 1
         assert self.mock_resolve_reviewers_as_refs.call_args_list[0][0][0][0] == "a@b.com"
+        
         assert response.id == test_pr_id
 
         #compare the PR objects

--- a/azure-devops/azext_devops/test/repos/test_pull_request.py
+++ b/azure-devops/azext_devops/test/repos/test_pull_request.py
@@ -156,11 +156,11 @@ class TestPullRequestMethods(AuthenticatedTests):
         organization = self._TEST_DEVOPS_ORGANIZATION)
 
         # assert
-        self.mock_validate_token.assert_not_called()
+        # self.mock_validate_token.assert_not_called()
         self.mock_create_PR.assert_called_once()
         self.mock_update_PR.assert_not_called()
         assert len(self.mock_resolve_reviewers_as_refs.call_args_list) == 1
-        assert self.mock_resolve_reviewers_as_refs.call_args_list[0][0][0] == ["a@b.com"]
+        assert self.mock_resolve_reviewers_as_refs.call_args_list[0][0][0][0] == "a@b.com"
         assert response.id == test_pr_id
 
         #compare the PR objects

--- a/azure-devops/azext_devops/test/repos/test_pull_request.py
+++ b/azure-devops/azext_devops/test/repos/test_pull_request.py
@@ -124,9 +124,6 @@ class TestPullRequestMethods(AuthenticatedTests):
         self.mock_validate_token.assert_not_called()
         self.mock_create_PR.assert_called_once()
         self.mock_update_PR.assert_not_called()
-        assert len(self.mock_resolve_reviewers_as_refs.call_args_list) == 1
-        assert self.mock_resolve_reviewers_as_refs.call_args_list[0][0][0] == [
-            "a@b.com"]
         assert response.id == test_pr_id
 
         #compare the PR objects
@@ -156,12 +153,12 @@ class TestPullRequestMethods(AuthenticatedTests):
         organization = self._TEST_DEVOPS_ORGANIZATION)
 
         # assert
-        # self.mock_validate_token.assert_not_called()
+        self.mock_validate_token.assert_not_called()
         self.mock_create_PR.assert_called_once()
         self.mock_update_PR.assert_not_called()
         assert len(self.mock_resolve_reviewers_as_refs.call_args_list) == 1
-        assert self.mock_resolve_reviewers_as_refs.call_args_list[0][0][0][0] == "a@b.com"
-        
+        assert self.mock_resolve_reviewers_as_refs.call_args_list[0][0][0] == ["a@b.com"]
+
         assert response.id == test_pr_id
 
         #compare the PR objects

--- a/azure-devops/azext_devops/test/repos/test_pull_request.py
+++ b/azure-devops/azext_devops/test/repos/test_pull_request.py
@@ -124,6 +124,9 @@ class TestPullRequestMethods(AuthenticatedTests):
         self.mock_validate_token.assert_not_called()
         self.mock_create_PR.assert_called_once()
         self.mock_update_PR.assert_not_called()
+        assert len(self.mock_resolve_reviewers_as_refs.call_args_list) == 1
+        assert self.mock_resolve_reviewers_as_refs.call_args_list[0][0][0] == [
+            "a@b.com"]
         assert response.id == test_pr_id
 
         #compare the PR objects
@@ -141,7 +144,7 @@ class TestPullRequestMethods(AuthenticatedTests):
 
         # set return values
         self.mock_create_PR.return_value.id = test_pr_id
-        self.mock_resolve_reviewers_as_ids.return_value = ['id1']
+        self.mock_resolve_reviewers_as_refs.return_value = ['id1']
 
         response = create_pull_request(project = self._TEST_PROJECT_NAME,
         repository = self._TEST_REPOSITORY_NAME,
@@ -156,6 +159,8 @@ class TestPullRequestMethods(AuthenticatedTests):
         self.mock_validate_token.assert_not_called()
         self.mock_create_PR.assert_called_once()
         self.mock_update_PR.assert_not_called()
+        assert len(self.mock_resolve_reviewers_as_refs.call_args_list) == 1
+        assert self.mock_resolve_reviewers_as_refs.call_args_list[0][0][0] == ["a@b.com"]
         assert response.id == test_pr_id
 
         #compare the PR objects
@@ -165,6 +170,7 @@ class TestPullRequestMethods(AuthenticatedTests):
         assert pr_object_from_create_call.source_ref_name == resolve_git_ref_heads(self._TEST_SOURCE_BRANCH)
         assert pr_object_from_create_call.target_ref_name == resolve_git_ref_heads(self._TEST_TARGET_BRANCH)
         assert pr_object_from_create_call.work_item_refs == None
+        assert pr_object_from_create_call.reviewers == ['id1']
 
     def test_create_pull_request_with_auto_complete(self):
 

--- a/azure-devops/azext_devops/test/repos/test_pull_request.py
+++ b/azure-devops/azext_devops/test/repos/test_pull_request.py
@@ -134,6 +134,38 @@ class TestPullRequestMethods(AuthenticatedTests):
         assert pr_object_from_create_call.target_ref_name == resolve_git_ref_heads(self._TEST_TARGET_BRANCH)
         assert pr_object_from_create_call.work_item_refs == None
 
+
+    def test_create_pull_request_with_duplicate_reviwer(self):
+
+        test_pr_id = 1
+
+        # set return values
+        self.mock_create_PR.return_value.id = test_pr_id
+        self.mock_resolve_reviewers_as_ids.return_value = ['id1']
+
+        response = create_pull_request(project = self._TEST_PROJECT_NAME,
+        repository = self._TEST_REPOSITORY_NAME,
+        source_branch = self._TEST_SOURCE_BRANCH,
+        target_branch = self._TEST_TARGET_BRANCH,
+        title = self._TEST_PR_TITLE,
+        description = self._TEST_PR_DESCRIPTION,    
+        reviewers = ['a@b.com','A@b.com'],
+        organization = self._TEST_DEVOPS_ORGANIZATION)
+
+        # assert
+        self.mock_validate_token.assert_not_called()
+        self.mock_create_PR.assert_called_once()
+        self.mock_update_PR.assert_not_called()
+        assert response.id == test_pr_id
+
+        #compare the PR objects
+        pr_object_from_create_call = self.mock_create_PR.call_args_list[0][1]['git_pull_request_to_create']
+        assert pr_object_from_create_call.title == self._TEST_PR_TITLE
+        assert pr_object_from_create_call.description == '\n'.join(self._TEST_PR_DESCRIPTION)
+        assert pr_object_from_create_call.source_ref_name == resolve_git_ref_heads(self._TEST_SOURCE_BRANCH)
+        assert pr_object_from_create_call.target_ref_name == resolve_git_ref_heads(self._TEST_TARGET_BRANCH)
+        assert pr_object_from_create_call.work_item_refs == None
+
     def test_create_pull_request_with_auto_complete(self):
 
         test_pr_id = 1


### PR DESCRIPTION
Please make sure the code is following contribution guidelines in CONTRIBUTING.md

 - [ ] : This PR has a corresponding issue open in the Repository.
 - [ ] : Approach is signed off on the issue.

Fixes: #1118 

`reviewers = list(set(x.lower() for x in reviewers))`
using above code snippet to discard duplicate reviewer
As reviewers object is list of email Ids, it is safe to do apply `.lower()`
