### PR TITLE
Use x86_64 version of artifact tool for M1 macs (using Rosetta)

### DIFF
--- a/azure-devops/azext_devops/dev/common/artifacttool_updater.py
+++ b/azure-devops/azext_devops/dev/common/artifacttool_updater.py
@@ -158,10 +158,18 @@ def _get_current_release(organization, override_version):
     # Distro returns empty strings on Windows currently, so don't even send
     distro_name = distro.id() or None
     distro_version = distro.version() or None
+    os_name = platform.system()
+    arch = platform.machine()
+
+    # For M1 macs, there is no version of artifact tool. However, the x86_64
+    # version can run under Rosetta, so we use that instead.
+    if os_name == "Darwin" and arch == "amd64":
+        arch = "x86_64"
+
     release = client.get_clienttool_release(
         "ArtifactTool",
-        os_name=platform.system(),
-        arch=platform.machine(),
+        os_name=os_name,
+        arch=arch,
         distro_name=distro_name,
         distro_version=distro_version,
         version=override_version)

--- a/azure-devops/azext_devops/dev/common/artifacttool_updater.py
+++ b/azure-devops/azext_devops/dev/common/artifacttool_updater.py
@@ -163,7 +163,7 @@ def _get_current_release(organization, override_version):
 
     # For M1 macs, there is no version of artifact tool. However, the x86_64
     # version can run under Rosetta, so we use that instead.
-    if os_name == "Darwin" and arch == "amd64":
+    if os_name == "Darwin" and arch in ["amd64", "arm64"]:
         arch = "x86_64"
 
     release = client.get_clienttool_release(


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-devops-cli-extension/issues/1006

There is no version of artifacttool which runs natively on an M1 mac (which uses Apple Silicon / ARM). This PR overrides the architecture to `x86_64` on those macs so that the "intel" version is downloaded, which will run under Rosetta.

There are 2 alternatives:

1. artifacttool has an arm compatible version created - This is not possible as artifacttool is an internal Microsoft tool which does not have its source published.
2. The server could handle this change - It would not be able to tell between a request for the intel on, or _really_ for an ARM one if/when it is available later. 

 - [ ] : Approach is signed off on the issue.
 - [x] : This PR has a corresponding issue open in the Repository.
