### PR TITLE
Fix broken az devops auth

### DIFF
--- a/azure-devops/azext_devops/dev/common/services.py
+++ b/azure-devops/azext_devops/dev/common/services.py
@@ -154,7 +154,8 @@ def get_token_from_az_logins(organization, pat_token_present):
 
 def get_token_from_az_login(profile, user, tenant):
     try:
-        auth_token = profile.get_access_token_for_resource(user, tenant, '499b84ac-1321-427f-aa17-267ca6975798')
+        creds, subscription, tenant = profile.get_raw_token(resource='499b84ac-1321-427f-aa17-267ca6975798', tenant=tenant)
+        auth_token = creds[1]
         return auth_token
     except BaseException as ex:  # pylint: disable=broad-except
         logger.debug('not able to get token from az login')


### PR DESCRIPTION
Updating get_token_from_az_login to use profile.get_raw_token instead of profile.get_access_token_for_resource (which was removed in the MSAL auth migration).

Fixes #1220 

Verified by running: 
az logout
az artifacts universal download (tried downloading an artifact to make sure I was logged out)
az login
az artifacts universal download (successfully downloaded with this change applied)