### PR TITLE
Allow setting remote related WI relations

### DIFF
--- a/azure-devops/azext_devops/dev/boards/arguments.py
+++ b/azure-devops/azext_devops/dev/boards/arguments.py
@@ -35,6 +35,8 @@ def load_work_arguments(self, _):
         context.argument('relation_type', help='Relation type to create. Example: parent, child ')
         context.argument('target_id', help='ID(s) of work-items to create relation with. \
                          Multiple values can be passed comma separated. Example: 1,2 ')
+        context.argument('target_url', help='URL(s) of work-items to create relation with. \
+                         Multiple values can be passed comma separated.')
 
     with self.argument_context('boards work-item relation remove') as context:
         context.argument('relation_type', help='Relation type to remove. Example: parent, child ')

--- a/azure-devops/azext_devops/dev/boards/relations.py
+++ b/azure-devops/azext_devops/dev/boards/relations.py
@@ -25,7 +25,7 @@ def add_relation(id, relation_type, target_id=None, target_url=None, organizatio
     """ Add relation(s) to work item.
     """
 
-    if target_id == None and target_url == None:
+    if target_id is None and target_url is None:
         raise CLIError('--target-id or --target-url shall be provided')
 
     organization = resolve_instance(detect=detect, organization=organization)

--- a/azure-devops/azext_devops/dev/boards/relations.py
+++ b/azure-devops/azext_devops/dev/boards/relations.py
@@ -26,7 +26,7 @@ def add_relation(id, relation_type, target_id=None, target_url=None, organizatio
     """
 
     if target_id is None and target_url is None:
-        raise CLIError('--target-id or --target-url shall be provided')
+        raise CLIError('--target-id or --target-url must be provided')
 
     organization = resolve_instance(detect=detect, organization=organization)
     patch_document = []


### PR DESCRIPTION
Please make sure the code is following contribution guidelines in CONTRIBUTING.md

 - [ ] : This PR has a corresponding issue open in the Repository.
 - [ ] : Approach is signed off on the issue.

Fixes: #1109 

Added `--target-url` subcommand to support WI URL to add as the relation.

 `--target-url` and  `--target-id` both can be added in a single command.