### PR TITLE
[pipelines][create] Add partial support for github enterprise

### DIFF
--- a/azure-devops/azext_devops/dev/pipelines/arguments.py
+++ b/azure-devops/azext_devops/dev/pipelines/arguments.py
@@ -79,7 +79,7 @@ def load_build_arguments(self, _):
             type=str.lower)
 
     with self.argument_context('pipelines create') as context:
-        context.argument('repository_type', choices=['tfsgit', 'github'], type=str.lower)
+        context.argument('repository_type', choices=['tfsgit', 'github', 'githubenterprise'], type=str.lower)
         context.argument('yml_path', options_list=('--yml-path', '--yaml-path'))
         context.argument('skip_first_run', options_list=['--skip-first-run', '--skip-run'],
                          arg_type=get_three_state_flag())


### PR DESCRIPTION
This change add partial for support for creating pipelines for github enterprise repos.

It is partial because it only supports creating pipelines with existing yaml files, requiring  `--yaml-path`.

Partially addresses #620

Please make sure the code is following contribution guidelines in CONTRIBUTING.md

 - [x] : This PR has a corresponding issue open in the Repository.
 - [ ] : Approach is signed off on the issue.
