### PR TITLE
update azure pipelines deprecated vm image to latest

### DIFF
--- a/.azure-pipelines/azure-pipelines-create-release.yml
+++ b/.azure-pipelines/azure-pipelines-create-release.yml
@@ -65,7 +65,7 @@ jobs:
 - job: 'Calculate_Sha_And_Create_Release'
   dependsOn : Run_Test
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-latest'
   variables:
     CLIVersion: $[dependencies.Run_Test.outputs['setupVersion.CLIVersion']]
     RTitle: $[dependencies.Run_Test.outputs['setupVersion.RTitle']]

--- a/.azure-pipelines/azure-pipelines-merge.yml
+++ b/.azure-pipelines/azure-pipelines-merge.yml
@@ -41,7 +41,7 @@ jobs:
 - job: 'Run_Test_Windows'
   dependsOn : [ 'Build_Publish_Azure_CLI_Test_SDK', 'Build_Publish_Azure_DevOps_CLI_Extension']
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-latest'
 
   steps:
   - task: PowerShell@2
@@ -201,7 +201,7 @@ jobs:
 
 - job: 'Check_Back_Compat_Arguments'
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-latest'
 
   steps:
   - task: UsePythonVersion@0
@@ -225,7 +225,7 @@ jobs:
 
 - job: 'Run_Markdown_Lint_Check'
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-latest'
 
   steps:
   - script: gem install chef-utils -v 16.6.14

--- a/.azure-pipelines/azure-pipelines-pr.yml
+++ b/.azure-pipelines/azure-pipelines-pr.yml
@@ -81,7 +81,7 @@ jobs:
 - job: 'Run_Test_Windows'
   dependsOn : Build_Publish_Azure_CLI_Test_SDK
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-latest'
 
   steps:
   - task: PowerShell@2
@@ -197,7 +197,7 @@ jobs:
 
 - job: 'Check_Back_Compat_Arguments'
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-latest'
 
   steps:
   - task: UsePythonVersion@0
@@ -221,7 +221,7 @@ jobs:
 
 - job: 'Run_Markdown_Lint_Check'
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-latest'
   
   steps:
   - script: gem install chef-utils -v 16.6.14

--- a/doc/samples.md
+++ b/doc/samples.md
@@ -263,7 +263,7 @@ jobs:
 - job:
   displayName: 'Windows'
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-latest'
   steps:
   - template: azure-pipelines-steps-win.yml
 ```


### PR DESCRIPTION
Fixes #1251 (Azure Pipelines "vs2017-win2016" vm image retires next month)

Adding a PR because the deadline for this change is fast approaching.

 - [X] : This PR has a corresponding issue open in the Repository.
 - [ ] : Approach is signed off on the issue.
