### PR TITLE
Fix incorrect Azure CLI reference links

### DIFF
--- a/doc/command_mapping.md
+++ b/doc/command_mapping.md
@@ -1,6 +1,6 @@
 # Command Mapping
 
-> Updated till azure-devops extension version 0.13.0. This file is no longer maintained. Please check latest azure-devops [command reference](https://docs.microsoft.com/en-us/cli/azure/ext/azure-devops) for command availability.
+> Updated till azure-devops extension version 0.13.0. This file is no longer maintained. Please check latest Azure CLI DevOps [command reference](https://docs.microsoft.com/cli/azure/devops) for command availability.
 
 The following table provides the mapping of commands from VSTS CLI to Azure DevOps Extension.
 


### PR DESCRIPTION
Bulk update: Edit incorrect Azure CLI reference links by removing /ext.

This work is in accordance with [User Story 1948095](https://dev.azure.com/mseng/TechnicalContent/_workitems/edit/1948095).

Please make sure the code is following contribution guidelines in CONTRIBUTING.md

 - [ ] : This PR has a corresponding issue open in the Repository.
 - [ ] : Approach is signed off on the issue.
