### PR TITLE
Fixed default order of the identities

### DIFF
--- a/azure-devops/azext_devops/dev/common/services.py
+++ b/azure-devops/azext_devops/dev/common/services.py
@@ -121,7 +121,7 @@ def get_token_from_az_logins(organization, pat_token_present):
 
     # first loop to make sure the first identity we try with is coming from selected subscription
     for subscription in subscriptions:
-        if subscription['isDefault'] == "true":
+        if subscription['isDefault']:
             tenantsDict[(subscription['tenantId'], subscription['user']['name'])] = ''
 
     for subscription in subscriptions:


### PR DESCRIPTION
get_token_from_az_logins() method uses the wrong comparison when finding an active subscription from az login data. The code fails to insert active subscription as first identity without outputting any errors or warning. 

This PR fixes comparison and active subscription is added into tenantsDict as first item.


Compare with get_default_subscription_info() in same file.

Please make sure the code is following contribution guidelines in CONTRIBUTING.md

 - [ ] : This PR has a corresponding issue open in the Repository.
 - [ ] : Approach is signed off on the issue.
