### PR TITLE
Add mapping for Windows ARM64 to x86_64 artifacttool, similar to work…

### DIFF
--- a/azure-devops/azext_devops/dev/common/artifacttool_updater.py
+++ b/azure-devops/azext_devops/dev/common/artifacttool_updater.py
@@ -166,6 +166,11 @@ def _get_current_release(organization, override_version):
     if os_name == "Darwin" and arch in ["amd64", "arm64"]:
         arch = "x86_64"
 
+    # Similarly for Windows ARM64 targets there is no version of artifact tool. However, the x86_64
+    # version can run under emulation, so we use that instead.
+    if os_name == "Windows" and arch == "ARM64":
+        arch = "x86_64"
+
     release = client.get_clienttool_release(
         "ArtifactTool",
         os_name=os_name,


### PR DESCRIPTION
…around for Darwin.  
Issue: https://developercommunity.visualstudio.com/t/azure-devops-cli-extension-issues-on-ARM/10084070

Please make sure the code is following contribution guidelines in CONTRIBUTING.md

 - [] : This PR has a corresponding issue open in the Repository.
 - [ ] : Approach is signed off on the issue.
