### PR TITLE
Fixes for flake8 failures in latest release pipeline results

### DIFF
--- a/azure-devops/azext_devops/dev/common/_credentials.py
+++ b/azure-devops/azext_devops/dev/common/_credentials.py
@@ -81,7 +81,7 @@ def normalize_url_for_key(url):
     components = uri_parse(url)
     normalized_url = components.scheme.lower() + '://' + components.netloc.lower()
     organization_name = components.path.lower()
-    if(organization_name and ('visualstudio.com' not in url.lower())):
+    if (organization_name and ('visualstudio.com' not in url.lower())):
         organization_name = organization_name.split('/')[1]
         normalized_url = normalized_url + '/' + organization_name
     return normalized_url

--- a/azure-devops/azext_devops/dev/common/credential_store.py
+++ b/azure-devops/azext_devops/dev/common/credential_store.py
@@ -89,7 +89,7 @@ class CredentialStore:
                 file_token = self.get_PAT_from_file(key)
                 if file_token:
                     self.delete_PAT_from_file(key)
-            if(keyring_token is None and file_token is None):
+            if (keyring_token is None and file_token is None):
                 raise CLIError(self._CRDENTIAL_NOT_FOUND_MSG)
         else:
             try:

--- a/azure-devops/azext_devops/dev/team/invoke.py
+++ b/azure-devops/azext_devops/dev/team/invoke.py
@@ -45,7 +45,7 @@ def invoke(area=None, resource=None,
 
     resource_areas = connection._get_resource_areas(force=True)
 
-    if(not area and not resource):
+    if (not area and not resource):
         print('Please wait a couple of seconds while we fetch all required information.')
         service_list = []
 


### PR DESCRIPTION
The latest release pipeline run has failures for flake8:
https://dev.azure.com/ms/azure-devops-cli-extension/_build/results?buildId=343344&view=logs&j=80f57011-57e2-5285-6819-df5013f56833&t=615f2ee2-d39f-5ed7-cc5d-f92e2c71ab0c

 - [x] : This PR has a corresponding issue open in the Repository.
 - [x] : Approach is signed off on the issue.
