### PR TITLE
Add `--definition-environment-id` to `az pipelines release list`

### DIFF
--- a/azure-devops/azext_devops/dev/pipelines/release.py
+++ b/azure-devops/azext_devops/dev/pipelines/release.py
@@ -79,11 +79,13 @@ def release_show(id, open=False, organization=None, project=None, detect=None): 
     return release
 
 
-def release_list(definition_id=None, min_created_time=None, max_created_time=None, source_branch=None,
-                 organization=None, project=None, detect=None, top=None, status=None):
+def release_list(definition_id=None, definition_environment_id=None, min_created_time=None, max_created_time=None,
+                 source_branch=None, organization=None, project=None, detect=None, top=None, status=None):
     """List release results.
     :param definition_id: ID of definition to list releases for.
     :type definition_id: int
+    :param definition_environment_id: ID of environment to list releases for.
+    :type definition_environment_id: int
     :param min_created_time: Releases that were created after this time.
     :type min_created_time: datetime
     :param max_created_time: Releases that were created before this time.
@@ -103,6 +105,7 @@ def release_list(definition_id=None, min_created_time=None, max_created_time=Non
     client = get_release_client(organization)
 
     releases = client.get_releases(definition_id=definition_id,
+                                   definition_environment_id=definition_environment_id,
                                    min_created_time=min_created_time,
                                    max_created_time=max_created_time,
                                    project=project,


### PR DESCRIPTION
Added the parameter `--definition-environment-id` to `az pipelines release list`. Approach was so simple I decided to go ahead on the PR.

 - [x] : This PR has a corresponding issue open in the Repository. (#1341)
 - [x] : Approach is signed off on the issue. 
