### PR TITLE
Add `--[min/max]-created-time` to `az pipelines release list`

### DIFF
--- a/azure-devops/azext_devops/dev/pipelines/release.py
+++ b/azure-devops/azext_devops/dev/pipelines/release.py
@@ -79,11 +79,15 @@ def release_show(id, open=False, organization=None, project=None, detect=None): 
     return release
 
 
-def release_list(definition_id=None, source_branch=None, organization=None, project=None, detect=None, top=None,
-                 status=None):
+def release_list(definition_id=None, min_created_time=None, max_created_time=None, source_branch=None,
+                 organization=None, project=None, detect=None, top=None, status=None):
     """List release results.
     :param definition_id: ID of definition to list releases for.
     :type definition_id: int
+    :param min_created_time: Releases that were created after this time.
+    :type min_created_time: datetime
+    :param max_created_time: Releases that were created before this time.
+    :type max_created_time: datetime
     :param branch: Filter by releases for this branch.
     :type branch: str
     :param top: Maximum number of releases to list. Default is 50.
@@ -99,6 +103,8 @@ def release_list(definition_id=None, source_branch=None, organization=None, proj
     client = get_release_client(organization)
 
     releases = client.get_releases(definition_id=definition_id,
+                                   min_created_time=min_created_time,
+                                   max_created_time=max_created_time,
                                    project=project,
                                    source_branch_filter=source_branch,
                                    top=top,


### PR DESCRIPTION
Added the parameters `--min-created-time` and `--max-created-time` to `az pipelines release list`. Approach was so simple I decided to go ahead on the PR.

 - [x] : This PR has a corresponding issue open in the Repository. (#1343)
 - [x] : Approach is signed off on the issue.
