### PR TITLE
Fix SyntaxWarning: invalid escape sequence

### DIFF
--- a/azure-devops/azext_devops/devops_sdk/v5_0/feed/models.py
+++ b/azure-devops/azext_devops/devops_sdk/v5_0/feed/models.py
@@ -112,7 +112,7 @@ class FeedCore(Model):
     :type id: str
     :param is_read_only: If set, all packages in the feed are immutable.  It is important to note that feed views are immutable; therefore, this flag will always be set for views.
     :type is_read_only: bool
-    :param name: A name for the feed. feed names must follow these rules: <list type="bullet"><item><description> Must not exceed 64 characters </description></item><item><description> Must not contain whitespaces </description></item><item><description> Must not start with an underscore or a period </description></item><item><description> Must not end with a period </description></item><item><description> Must not contain any of the following illegal characters: <![CDATA[ @, ~, ;, {, }, \, +, =, <, >, |, /, \\, ?, :, &, $, *, \", #, [, ] ]]></description></item></list>
+    :param name: A name for the feed. feed names must follow these rules: <list type="bullet"><item><description> Must not exceed 64 characters </description></item><item><description> Must not contain whitespaces </description></item><item><description> Must not start with an underscore or a period </description></item><item><description> Must not end with a period </description></item><item><description> Must not contain any of the following illegal characters: <![CDATA[ @, ~, ;, {, }, \\, +, =, <, >, |, /, \\, ?, :, &, $, *, \", #, [, ] ]]></description></item></list>
     :type name: str
     :param upstream_enabled: OBSOLETE: This should always be true.  Setting to false will override all sources in UpstreamSources.
     :type upstream_enabled: bool
@@ -220,7 +220,7 @@ class FeedUpdate(Model):
     :type hide_deleted_package_versions: bool
     :param id: A GUID that uniquely identifies this feed.
     :type id: str
-    :param name: A name for the feed. feed names must follow these rules: <list type="bullet"><item><description> Must not exceed 64 characters </description></item><item><description> Must not contain whitespaces </description></item><item><description> Must not start with an underscore or a period </description></item><item><description> Must not end with a period </description></item><item><description> Must not contain any of the following illegal characters: <![CDATA[ @, ~, ;, {, }, \, +, =, <, >, |, /, \\, ?, :, &, $, *, \", #, [, ] ]]></description></item></list>
+    :param name: A name for the feed. feed names must follow these rules: <list type="bullet"><item><description> Must not exceed 64 characters </description></item><item><description> Must not contain whitespaces </description></item><item><description> Must not start with an underscore or a period </description></item><item><description> Must not end with a period </description></item><item><description> Must not contain any of the following illegal characters: <![CDATA[ @, ~, ;, {, }, \\, +, =, <, >, |, /, \\, ?, :, &, $, *, \", #, [, ] ]]></description></item></list>
     :type name: str
     :param upstream_enabled: OBSOLETE: If set, the feed can proxy packages from an upstream feed
     :type upstream_enabled: bool
@@ -996,7 +996,7 @@ class Feed(FeedCore):
     :type id: str
     :param is_read_only: If set, all packages in the feed are immutable.  It is important to note that feed views are immutable; therefore, this flag will always be set for views.
     :type is_read_only: bool
-    :param name: A name for the feed. feed names must follow these rules: <list type="bullet"><item><description> Must not exceed 64 characters </description></item><item><description> Must not contain whitespaces </description></item><item><description> Must not start with an underscore or a period </description></item><item><description> Must not end with a period </description></item><item><description> Must not contain any of the following illegal characters: <![CDATA[ @, ~, ;, {, }, \, +, =, <, >, |, /, \\, ?, :, &, $, *, \", #, [, ] ]]></description></item></list>
+    :param name: A name for the feed. feed names must follow these rules: <list type="bullet"><item><description> Must not exceed 64 characters </description></item><item><description> Must not contain whitespaces </description></item><item><description> Must not start with an underscore or a period </description></item><item><description> Must not end with a period </description></item><item><description> Must not contain any of the following illegal characters: <![CDATA[ @, ~, ;, {, }, \\, +, =, <, >, |, /, \\, ?, :, &, $, *, \", #, [, ] ]]></description></item></list>
     :type name: str
     :param upstream_enabled: OBSOLETE: This should always be true.  Setting to false will override all sources in UpstreamSources.
     :type upstream_enabled: bool

--- a/azure-devops/azext_devops/devops_sdk/v5_1/feed/models.py
+++ b/azure-devops/azext_devops/devops_sdk/v5_1/feed/models.py
@@ -113,7 +113,7 @@ class FeedCore(Model):
     :type id: str
     :param is_read_only: If set, all packages in the feed are immutable.  It is important to note that feed views are immutable; therefore, this flag will always be set for views.
     :type is_read_only: bool
-    :param name: A name for the feed. feed names must follow these rules: <list type="bullet"><item><description> Must not exceed 64 characters </description></item><item><description> Must not contain whitespaces </description></item><item><description> Must not start with an underscore or a period </description></item><item><description> Must not end with a period </description></item><item><description> Must not contain any of the following illegal characters: <![CDATA[ @, ~, ;, {, }, \, +, =, <, >, |, /, \\, ?, :, &, $, *, \", #, [, ] ]]></description></item></list>
+    :param name: A name for the feed. feed names must follow these rules: <list type="bullet"><item><description> Must not exceed 64 characters </description></item><item><description> Must not contain whitespaces </description></item><item><description> Must not start with an underscore or a period </description></item><item><description> Must not end with a period </description></item><item><description> Must not contain any of the following illegal characters: <![CDATA[ @, ~, ;, {, }, \\, +, =, <, >, |, /, \\, ?, :, &, $, *, \", #, [, ] ]]></description></item></list>
     :type name: str
     :param project: The project that this feed is associated with.
     :type project: :class:`ProjectReference <azure.devops.v5_1.packaging.models.ProjectReference>`
@@ -232,7 +232,7 @@ class FeedUpdate(Model):
     :type hide_deleted_package_versions: bool
     :param id: A GUID that uniquely identifies this feed.
     :type id: str
-    :param name: A name for the feed. feed names must follow these rules: <list type="bullet"><item><description> Must not exceed 64 characters </description></item><item><description> Must not contain whitespaces </description></item><item><description> Must not start with an underscore or a period </description></item><item><description> Must not end with a period </description></item><item><description> Must not contain any of the following illegal characters: <![CDATA[ @, ~, ;, {, }, \, +, =, <, >, |, /, \\, ?, :, &, $, *, \", #, [, ] ]]></description></item></list>
+    :param name: A name for the feed. feed names must follow these rules: <list type="bullet"><item><description> Must not exceed 64 characters </description></item><item><description> Must not contain whitespaces </description></item><item><description> Must not start with an underscore or a period </description></item><item><description> Must not end with a period </description></item><item><description> Must not contain any of the following illegal characters: <![CDATA[ @, ~, ;, {, }, \\, +, =, <, >, |, /, \\, ?, :, &, $, *, \", #, [, ] ]]></description></item></list>
     :type name: str
     :param upstream_enabled: OBSOLETE: If set, the feed can proxy packages from an upstream feed
     :type upstream_enabled: bool
@@ -1061,7 +1061,7 @@ class Feed(FeedCore):
     :type id: str
     :param is_read_only: If set, all packages in the feed are immutable.  It is important to note that feed views are immutable; therefore, this flag will always be set for views.
     :type is_read_only: bool
-    :param name: A name for the feed. feed names must follow these rules: <list type="bullet"><item><description> Must not exceed 64 characters </description></item><item><description> Must not contain whitespaces </description></item><item><description> Must not start with an underscore or a period </description></item><item><description> Must not end with a period </description></item><item><description> Must not contain any of the following illegal characters: <![CDATA[ @, ~, ;, {, }, \, +, =, <, >, |, /, \\, ?, :, &, $, *, \", #, [, ] ]]></description></item></list>
+    :param name: A name for the feed. feed names must follow these rules: <list type="bullet"><item><description> Must not exceed 64 characters </description></item><item><description> Must not contain whitespaces </description></item><item><description> Must not start with an underscore or a period </description></item><item><description> Must not end with a period </description></item><item><description> Must not contain any of the following illegal characters: <![CDATA[ @, ~, ;, {, }, \\, +, =, <, >, |, /, \\, ?, :, &, $, *, \", #, [, ] ]]></description></item></list>
     :type name: str
     :param project: The project that this feed is associated with.
     :type project: :class:`ProjectReference <azure.devops.v5_1.packaging.models.ProjectReference>`

--- a/azure-devops/azext_devops/devops_sdk/v6_0/feed/models.py
+++ b/azure-devops/azext_devops/devops_sdk/v6_0/feed/models.py
@@ -113,7 +113,7 @@ class FeedCore(Model):
     :type id: str
     :param is_read_only: If set, all packages in the feed are immutable.  It is important to note that feed views are immutable; therefore, this flag will always be set for views.
     :type is_read_only: bool
-    :param name: A name for the feed. feed names must follow these rules: <list type="bullet"><item><description> Must not exceed 64 characters </description></item><item><description> Must not contain whitespaces </description></item><item><description> Must not start with an underscore or a period </description></item><item><description> Must not end with a period </description></item><item><description> Must not contain any of the following illegal characters: <![CDATA[ @, ~, ;, {, }, \, +, =, <, >, |, /, \\, ?, :, &, $, *, \", #, [, ] ]]></description></item></list>
+    :param name: A name for the feed. feed names must follow these rules: <list type="bullet"><item><description> Must not exceed 64 characters </description></item><item><description> Must not contain whitespaces </description></item><item><description> Must not start with an underscore or a period </description></item><item><description> Must not end with a period </description></item><item><description> Must not contain any of the following illegal characters: <![CDATA[ @, ~, ;, {, }, \\, +, =, <, >, |, /, \\, ?, :, &, $, *, \", #, [, ] ]]></description></item></list>
     :type name: str
     :param project: The project that this feed is associated with.
     :type project: :class:`ProjectReference <azure.devops.v6_0.packaging.models.ProjectReference>`
@@ -236,7 +236,7 @@ class FeedUpdate(Model):
     :type hide_deleted_package_versions: bool
     :param id: A GUID that uniquely identifies this feed.
     :type id: str
-    :param name: A name for the feed. feed names must follow these rules: <list type="bullet"><item><description> Must not exceed 64 characters </description></item><item><description> Must not contain whitespaces </description></item><item><description> Must not start with an underscore or a period </description></item><item><description> Must not end with a period </description></item><item><description> Must not contain any of the following illegal characters: <![CDATA[ @, ~, ;, {, }, \, +, =, <, >, |, /, \\, ?, :, &, $, *, \", #, [, ] ]]></description></item></list>
+    :param name: A name for the feed. feed names must follow these rules: <list type="bullet"><item><description> Must not exceed 64 characters </description></item><item><description> Must not contain whitespaces </description></item><item><description> Must not start with an underscore or a period </description></item><item><description> Must not end with a period </description></item><item><description> Must not contain any of the following illegal characters: <![CDATA[ @, ~, ;, {, }, \\, +, =, <, >, |, /, \\, ?, :, &, $, *, \", #, [, ] ]]></description></item></list>
     :type name: str
     :param upstream_enabled: OBSOLETE: If set, the feed can proxy packages from an upstream feed
     :type upstream_enabled: bool
@@ -1092,7 +1092,7 @@ class Feed(FeedCore):
     :type id: str
     :param is_read_only: If set, all packages in the feed are immutable.  It is important to note that feed views are immutable; therefore, this flag will always be set for views.
     :type is_read_only: bool
-    :param name: A name for the feed. feed names must follow these rules: <list type="bullet"><item><description> Must not exceed 64 characters </description></item><item><description> Must not contain whitespaces </description></item><item><description> Must not start with an underscore or a period </description></item><item><description> Must not end with a period </description></item><item><description> Must not contain any of the following illegal characters: <![CDATA[ @, ~, ;, {, }, \, +, =, <, >, |, /, \\, ?, :, &, $, *, \", #, [, ] ]]></description></item></list>
+    :param name: A name for the feed. feed names must follow these rules: <list type="bullet"><item><description> Must not exceed 64 characters </description></item><item><description> Must not contain whitespaces </description></item><item><description> Must not start with an underscore or a period </description></item><item><description> Must not end with a period </description></item><item><description> Must not contain any of the following illegal characters: <![CDATA[ @, ~, ;, {, }, \\, +, =, <, >, |, /, \\, ?, :, &, $, *, \", #, [, ] ]]></description></item></list>
     :type name: str
     :param project: The project that this feed is associated with.
     :type project: :class:`ProjectReference <azure.devops.v6_0.packaging.models.ProjectReference>`


### PR DESCRIPTION
Loading azure-devops/azext_devops/devops_sdk/*/feed/models.py with Python 3.12 produces the following warnings:

    /path/to/azure-devops/azext_devops/devops_sdk/v5_0/feed/models.py:101: SyntaxWarning: invalid escape sequence '\,'
      """FeedCore.
    /path/to/azure-devops/azext_devops/devops_sdk/v5_0/feed/models.py:209: SyntaxWarning: invalid escape sequence '\,'
      """FeedUpdate.
    /path/to/azure-devops/azext_devops/devops_sdk/v5_0/feed/models.py:985: SyntaxWarning: invalid escape sequence '\,'
      """Feed.

This occurs due to the presence of the invalid escape sequence `\,` in docstrings for FeedCore, FeedUpdate, and Feed, which produces a SyntaxWarning in Python 3.12 as a result of <https://github.com/python/cpython/issues/98401>.

### Unresolved Issues

This PR changes `\,` to `\\,`, which avoids the SyntaxWarning, but doesn't fix the ambiguity of what is being communicated:  `\\,` now appears twice in the list.  Is the intention to indicate that comma and backslash are illegal?  Perhaps `,,` or `\\,,` would be clearer?

Thanks for considering,
Kevin