### PR TITLE
Add exist_ok to fix race condition in get_cache_dir

### DIFF
--- a/azure-devops/azext_devops/devops_sdk/_file_cache.py
+++ b/azure-devops/azext_devops/devops_sdk/_file_cache.py
@@ -114,7 +114,7 @@ def get_cache_dir():
     azure_devops_cache_dir = os.getenv('AZURE_DEVOPS_CACHE_DIR', None)\
                              or os.path.expanduser(os.path.join('~', '.azure-devops', 'python-sdk', 'cache'))
     if not os.path.exists(azure_devops_cache_dir):
-        os.makedirs(azure_devops_cache_dir)
+        os.makedirs(azure_devops_cache_dir, exist_ok=True)
     return azure_devops_cache_dir
 
 


### PR DESCRIPTION
Should fix #1270 race condition in get_cache_dir. Happens quite consistently in my CI pipeline. 

 - [x ] : This PR has a corresponding issue open in the Repository.
 - [ ] : Approach is signed off on the issue.
