### PR TITLE
Fix build pipeline by upgrading setuptools and wheel dependencies

### DIFF
--- a/.azure-pipelines/templates/setup-ci-machine.yml
+++ b/.azure-pipelines/templates/setup-ci-machine.yml
@@ -1,8 +1,8 @@
 steps:
 - script: python -m pip install --upgrade pip
   displayName: 'Upgrade pip'
-- script: python -m pip install --upgrade setuptools wheel
-  displayName: 'Install setuptools and wheel'
+- script: pip install wheel
+  displayName: 'Install Wheel'
 - script: "pip install 'pytest>=7.0.0'"
   displayName: 'Install pytest'
 - script: pip install coverage

--- a/.azure-pipelines/templates/setup-ci-machine.yml
+++ b/.azure-pipelines/templates/setup-ci-machine.yml
@@ -1,9 +1,9 @@
 steps:
 - script: python -m pip install --upgrade pip
   displayName: 'Upgrade pip'
-- script: pip install wheel==0.30.0
-  displayName: 'Install Wheel'
-- script: pip install pytest==6.2.5
+- script: python -m pip install --upgrade setuptools wheel
+  displayName: 'Install setuptools and wheel'
+- script: "pip install 'pytest>=7.0.0'"
   displayName: 'Install pytest'
 - script: pip install coverage
   displayName: 'Install coverage'


### PR DESCRIPTION
**Description**
Updated build dependencies in the pipeline to resolve wheel build failures.

**Changes**
- Replaced outdated `wheel==0.30.0` with upgraded `setuptools` and `wheel`
- Upgraded `pip` to ensure compatibility with modern packaging tools
- Updated pytest version to `>=7.0.0`
- Kept existing pipeline structure intact

 **Reason**
The pipeline was failing with:
`ModuleNotFoundError: No module named 'wheel.wheelfile'`