### PR TITLE
Align ELM migration enums and skip-validation policies with renamed server contract

### DIFF
--- a/azure-devops/azext_devops/dev/migration/arguments.py
+++ b/azure-devops/azext_devops/dev/migration/arguments.py
@@ -39,7 +39,7 @@ def load_migration_arguments(self, _):
                          help='Agent pool name to use for migration work.')
         context.argument('skip_validation', options_list='--skip-validation',
                          help='Validation policies to skip. Accepts either a comma-separated list of '
-                              'policy names (for example, AgentPoolExists,MaxRepoSize) or a non-negative '
+                              'policy names (for example, AgentPoolExists,MaxFileSize) or a non-negative '
                               'integer bitmask.')
         context.argument('service_endpoint_id', options_list='--service-endpoint-id',
                          help='Service endpoint ID (GUID) for the GitHub Enterprise Server connection. '

--- a/azure-devops/azext_devops/dev/migration/migration.py
+++ b/azure-devops/azext_devops/dev/migration/migration.py
@@ -46,8 +46,10 @@ _SKIP_VALIDATION_POLICIES = {
     'maxpullrequestsize': 16,
     'maxpushpacksize': 32,
     'maxreferencenamelength': 64,
-    'maxreposize': 128,
     'targetrepositorydoesnotexist': 256,
+    'sourcerepositorycontainslfsobjects': 512,
+    'sourcerepositorynotreadonly': 1024,
+    'boardsgithubconnectionprovisioning': 2048,
     'all': 2147483647,
 }
 _SUCCESS_TERMINAL_STATES = {
@@ -58,13 +60,21 @@ _NON_ACTIVE_STATES = {
     'completed',
     'succeeded',
     'failed',
-    'suspended'
+    'suspended',
+    'paused'
 }
 _ACTIVE_STAGES = {
     'queued',
     'validation',
     'synchronization',
     'cutover'
+}
+
+_MIGRATION_STATUS_VALUES = {
+    'active': 0,
+    'completed': 1,
+    'failed': 2,
+    'paused': 3,
 }
 _URL_PATTERN = re.compile(r'^https?://[^\s]+$', re.IGNORECASE)
 
@@ -114,7 +124,7 @@ def _parse_skip_validation(skip_validation):
     policies = [policy.strip() for policy in normalized.split(',')]
     if any(not policy for policy in policies):
         raise CLIError('--skip-validation contains an empty policy name. Provide a comma-separated '
-                       'list such as "AgentPoolExists,MaxRepoSize".')
+                       'list such as "AgentPoolExists,MaxFileSize".')
 
     mask = 0
     invalid_policies = []
@@ -141,8 +151,10 @@ def _parse_skip_validation(skip_validation):
                                    'MaxPullRequestSize',
                                    'MaxPushPackSize',
                                    'MaxReferenceNameLength',
-                                   'MaxRepoSize',
                                    'TargetRepositoryDoesNotExist',
+                                   'SourceRepositoryContainsLfsObjects',
+                                   'SourceRepositoryNotReadOnly',
+                                   'BoardsGitHubConnectionProvisioning',
                                    'All'
                                ])))
 
@@ -397,7 +409,8 @@ def _validate_target_repository(target_repository):
 
 
 def pause_migration(repository_id=None, organization=None, detect=None):
-    result = _update_migration(repository_id, organization, detect, status_requested='suspended')
+    result = _update_migration(repository_id, organization, detect,
+                               status_requested=_MIGRATION_STATUS_VALUES['paused'])
     if not result:
         return {'message': 'Migration paused successfully.'}
     return result
@@ -449,7 +462,8 @@ def resume_migration(repository_id=None, validate_only=False, migration=False, o
         validate_only_value = False
 
     return _update_migration(repository_id, organization, None,
-                             validate_only=validate_only_value, status_requested='active')
+                             validate_only=validate_only_value,
+                             status_requested=_MIGRATION_STATUS_VALUES['active'])
 
 
 def schedule_cutover(repository_id=None, cutover_date=None, organization=None, detect=None):
@@ -619,7 +633,8 @@ def _is_validate_only_succeeded(migration):
 def _promote_to_full_migration(migration_data, repository_id, organization):
     del migration_data
     return _update_migration(repository_id, organization, detect=None,
-                             validate_only=False, status_requested='active')
+                             validate_only=False,
+                             status_requested=_MIGRATION_STATUS_VALUES['active'])
 
 
 def _resolve_org_for_auth(organization, detect):

--- a/azure-devops/azext_devops/tests/latest/migration/test_migration.py
+++ b/azure-devops/azext_devops/tests/latest/migration/test_migration.py
@@ -709,7 +709,7 @@ class TestMigrationCommands(unittest.TestCase):
                 repository_id='00000000-0000-0000-0000-000000000000',
                 target_repository='https://example.ghe.com/OrgName/RepoName',
                 target_owner_user_id='TestOwner',
-                skip_validation='AgentPoolExists,,MaxRepoSize',
+                skip_validation='AgentPoolExists,,MaxFileSize',
                 organization=self._TEST_ORG,
                 detect=False
             )
@@ -1065,6 +1065,22 @@ class TestMigrationCommands(unittest.TestCase):
 
             self.assertEqual(result, migration_response)
 
+    def test_pause_returns_migration_data_when_service_responds_paused(self):
+        migration_response = {'repositoryId': '00000000-0000-0000-0000-000000000000', 'status': 'paused'}
+        with patch('azext_devops.dev.migration.migration.resolve_instance') as mock_resolve, \
+             patch('azext_devops.dev.migration.migration._get_service_client') as mock_client, \
+             patch('azext_devops.dev.migration.migration._send_request') as mock_send:
+            mock_send.return_value = migration_response
+            mock_resolve.return_value = self._TEST_ORG
+
+            result = pause_migration(
+                repository_id='00000000-0000-0000-0000-000000000000',
+                organization=self._TEST_ORG,
+                detect=False
+            )
+
+            self.assertEqual(result, migration_response)
+
     def test_list_migrations_warns_when_empty(self):
         with patch('azext_devops.dev.migration.migration.resolve_instance') as mock_resolve, \
              patch('azext_devops.dev.migration.migration._get_service_client') as mock_client, \
@@ -1160,7 +1176,7 @@ class TestMigrationCommands(unittest.TestCase):
 
             payload = mock_send.call_args[0][3]
             self.assertTrue(payload['validateOnly'])
-            self.assertEqual(payload['statusRequested'], 'active')
+            self.assertEqual(payload['statusRequested'], migration_module._MIGRATION_STATUS_VALUES['active'])
 
     def test_resume_sets_migration(self):
         with patch('azext_devops.dev.migration.migration.get_migration') as mock_get, \
@@ -1177,7 +1193,41 @@ class TestMigrationCommands(unittest.TestCase):
 
             payload = mock_send.call_args[0][3]
             self.assertFalse(payload['validateOnly'])
-            self.assertEqual(payload['statusRequested'], 'active')
+            self.assertEqual(payload['statusRequested'], migration_module._MIGRATION_STATUS_VALUES['active'])
+
+    def test_resume_sets_validate_only_when_status_paused(self):
+        with patch('azext_devops.dev.migration.migration.get_migration') as mock_get, \
+             patch('azext_devops.dev.migration.migration.resolve_instance') as mock_resolve, \
+             patch('azext_devops.dev.migration.migration._get_service_client') as mock_client, \
+             patch('azext_devops.dev.migration.migration._send_request') as mock_send:
+            mock_send.return_value = {}
+            mock_get.return_value = {'status': 'paused'}
+            mock_resolve.return_value = self._TEST_ORG
+
+            resume_migration(repository_id='00000000-0000-0000-0000-000000000000',
+                             validate_only=True,
+                             organization=self._TEST_ORG, detect=False)
+
+            payload = mock_send.call_args[0][3]
+            self.assertTrue(payload['validateOnly'])
+            self.assertEqual(payload['statusRequested'], migration_module._MIGRATION_STATUS_VALUES['active'])
+
+    def test_resume_sets_migration_when_status_paused(self):
+        with patch('azext_devops.dev.migration.migration.get_migration') as mock_get, \
+             patch('azext_devops.dev.migration.migration.resolve_instance') as mock_resolve, \
+             patch('azext_devops.dev.migration.migration._get_service_client') as mock_client, \
+             patch('azext_devops.dev.migration.migration._send_request') as mock_send:
+            mock_send.return_value = {}
+            mock_get.return_value = {'status': 'paused'}
+            mock_resolve.return_value = self._TEST_ORG
+
+            resume_migration(repository_id='00000000-0000-0000-0000-000000000000',
+                             migration=True,
+                             organization=self._TEST_ORG, detect=False)
+
+            payload = mock_send.call_args[0][3]
+            self.assertFalse(payload['validateOnly'])
+            self.assertEqual(payload['statusRequested'], migration_module._MIGRATION_STATUS_VALUES['active'])
 
     def test_resume_without_flags_preserves_mode(self):
         with patch('azext_devops.dev.migration.migration.get_migration') as mock_get, \
@@ -1193,7 +1243,7 @@ class TestMigrationCommands(unittest.TestCase):
 
             payload = mock_send.call_args[0][3]
             self.assertNotIn('validateOnly', payload)
-            self.assertEqual(payload['statusRequested'], 'active')
+            self.assertEqual(payload['statusRequested'], migration_module._MIGRATION_STATUS_VALUES['active'])
 
     def test_resume_migration_promotes_validate_only_succeeded(self):
         with patch('azext_devops.dev.migration.migration.get_migration') as mock_get, \
@@ -1215,7 +1265,7 @@ class TestMigrationCommands(unittest.TestCase):
             self.assertEqual(args[1], 'PUT')
             payload = args[3]
             self.assertFalse(payload['validateOnly'])
-            self.assertEqual(payload['statusRequested'], 'active')
+            self.assertEqual(payload['statusRequested'], migration_module._MIGRATION_STATUS_VALUES['active'])
 
     def test_resume_migration_promotes_validate_only_completed(self):
         with patch('azext_devops.dev.migration.migration.get_migration') as mock_get, \
@@ -1237,7 +1287,7 @@ class TestMigrationCommands(unittest.TestCase):
             self.assertEqual(args[1], 'PUT')
             payload = args[3]
             self.assertFalse(payload['validateOnly'])
-            self.assertEqual(payload['statusRequested'], 'active')
+            self.assertEqual(payload['statusRequested'], migration_module._MIGRATION_STATUS_VALUES['active'])
 
     def test_resume_migration_promote_uses_only_state_transition_fields(self):
         with patch('azext_devops.dev.migration.migration.get_migration') as mock_get, \
@@ -1262,7 +1312,7 @@ class TestMigrationCommands(unittest.TestCase):
 
             payload = mock_send.call_args[0][3]
             self.assertEqual(payload['validateOnly'], False)
-            self.assertEqual(payload['statusRequested'], 'active')
+            self.assertEqual(payload['statusRequested'], migration_module._MIGRATION_STATUS_VALUES['active'])
             self.assertEqual(set(payload.keys()), {'validateOnly', 'statusRequested'})
             self.assertNotIn('agentPoolName', payload)
             self.assertNotIn('scheduledCutoverDate', payload)

--- a/doc/elm_migrations_tsg.md
+++ b/doc/elm_migrations_tsg.md
@@ -386,7 +386,7 @@ az devops migrations resume --detect false --repository-id <GUID> --validate-onl
 Recommended form using policy names:
 
 ```powershell
-az devops migrations create --detect false --repository-id <GUID> --target-repository <TARGET_URL> --target-owner-user-id <OWNER> --skip-validation AgentPoolExists,MaxRepoSize
+az devops migrations create --detect false --repository-id <GUID> --target-repository <TARGET_URL> --target-owner-user-id <OWNER> --skip-validation AgentPoolExists,MaxFileSize
 ```
 
 Advanced form using integer bitmask:
@@ -398,7 +398,7 @@ az devops migrations create --detect false --repository-id <GUID> --target-repos
 Token/PAT-authenticated examples:
 
 ```powershell
-az devops migrations create --detect false --repository-id <GUID> --target-repository <TARGET_URL> --github-token <TOKEN_OR_PAT> --skip-validation AgentPoolExists,MaxRepoSize
+az devops migrations create --detect false --repository-id <GUID> --target-repository <TARGET_URL> --github-token <TOKEN_OR_PAT> --skip-validation AgentPoolExists,MaxFileSize
 az devops migrations create --detect false --repository-id <GUID> --target-repository <TARGET_URL> --github-token <TOKEN_OR_PAT> --skip-validation 132
 ```
 
@@ -412,8 +412,10 @@ Supported policy names:
 - `MaxPullRequestSize`
 - `MaxPushPackSize`
 - `MaxReferenceNameLength`
-- `MaxRepoSize`
 - `TargetRepositoryDoesNotExist`
+- `SourceRepositoryContainsLfsObjects`
+- `SourceRepositoryNotReadOnly`
+- `BoardsGitHubConnectionProvisioning`
 - `All`
 
 ### Promote validate-only does not start

--- a/doc/migrations.md
+++ b/doc/migrations.md
@@ -150,7 +150,7 @@ Recommended form using policy names:
 az devops migrations create --org https://dev.azure.com/myorg \
   --repository-id 00000000-0000-0000-0000-000000000000 \
   --target-repository https://example.ghe.com/OrgName/RepoName \
-  --skip-validation AgentPoolExists,MaxRepoSize
+  --skip-validation AgentPoolExists,MaxFileSize
 ```
 
 Advanced form using integer bitmask:
@@ -234,7 +234,7 @@ az devops migrations pause --org https://dev.azure.com/myorg \
   Pass `--github-token`, set `ELM_GITHUB_TOKEN`, or complete the interactive GitHub device-flow prompt shown by CLI.
 
 - Error: `--skip-validation` contains unsupported policy names.
-  Use supported names such as `AgentPoolExists`, `MaxRepoSize`, or pass a non-negative integer bitmask.
+  Use supported names such as `AgentPoolExists`, `MaxFileSize`, or pass a non-negative integer bitmask.
 
 - Error: requests are sent to the wrong org.
   Use `--org <url> --detect false`, and verify defaults via `az devops configure -l`.


### PR DESCRIPTION
## Summary

The ELM service renamed several `MigrationStatus` enum members and added more flags to the
`SkipValidationOptions` flag set. This PR aligns the CLI with the new server contract.

Testing:

I have done some E2E testing and made sure these new changes are working as expected