### PR TITLE
fix(elm): satisfy azdev linter for devops migrations help

### DIFF
--- a/azure-devops/azext_devops/dev/migration/_help.py
+++ b/azure-devops/azext_devops/dev/migration/_help.py
@@ -10,7 +10,7 @@ def load_migration_help():
     helps['devops migrations'] = """
     type: group
     short-summary: Manage enterprise live migrations.
-    long-summary: 'This command group is a part of the azure-devops extension and is in preview. Availability may be limited (for example, to 1P/allowlisted users). For ELM migrations, --org should be your Azure DevOps organization URL (for example: https://dev.azure.com/myorg).'
+    long-summary: 'This command group is a part of the azure-devops extension and is in preview. Availability may be limited (for example, to 1P/allowlisted users). For ELM migrations, --org should be your Azure DevOps organization URL (for example: `https://dev.azure.com/myorg`).'
     """
 
     helps['devops migrations list'] = """

--- a/azure-devops/azext_devops/dev/migration/arguments.py
+++ b/azure-devops/azext_devops/dev/migration/arguments.py
@@ -16,7 +16,7 @@ def load_migration_arguments(self, _):
 
     with self.argument_context('devops migrations pipelines') as context:
         context.argument('repository_mapping', options_list='--repository-mapping', action='append',
-                         help='Repository mapping in the format <sourceRepoId>=<targetOwner>/<targetRepo>. '
+                         help='Repository mapping in the format `<sourceRepoId>=<targetOwner>/<targetRepo>`. '
                               'Can be provided multiple times.')
 
     with self.argument_context('devops migrations pipelines submit') as context:
@@ -65,7 +65,7 @@ def load_migration_arguments(self, _):
 
     with self.argument_context('devops migrations create') as context:
         context.argument('target_repository', options_list='--target-repository',
-                         help='Target repository URL (must start with http:// or https://).')
+                         help='Target repository URL (must start with `http://` or `https://`).')
         context.argument('target_owner_user_id', options_list='--target-owner-user-id',
                          help='Target repository owner user ID. Deprecated and ignored when server-side '
                               'token-based owner resolution is enabled.')
@@ -97,13 +97,15 @@ def load_migration_arguments(self, _):
                               'verification: --github-token / ELM_GITHUB_TOKEN can be supplied '
                               'alongside this flag. Device flow is skipped when this flag is set.')
         context.argument('enable_boards_github_connection',
-                         options_list='--enable-boards-github-connection', action='store_true',
+                         options_list=['--enable-boards-github-connection', '--enable-boards-gh'],
+                         action='store_true',
                          help='Opt in to provisioning the Azure Boards GitHub connection at '
                               'cutover. Off by default. Requires the Azure Boards GitHub App '
                               'to be installed on the target GitHub Enterprise organization '
                               'before the migration runs.')
         context.argument('enable_auto_discover_pipelines',
-                         options_list='--enable-auto-discover-pipelines', action='store_true',
+                         options_list=['--enable-auto-discover-pipelines', '--auto-discover'],
+                         action='store_true',
                          help='Opt in to automatic pipeline discovery at cutover. Off by default. '
                               'When enabled, the ELM sync job walks the source repository and '
                               'creates clone definitions for every pipeline that references it. '
@@ -112,7 +114,7 @@ def load_migration_arguments(self, _):
                               'Pipeline rewiring itself is always available via '
                               'az devops migrations pipelines submit / update.')
         context.argument('pipeline_service_connection_id',
-                         options_list='--pipeline-service-connection-id',
+                         options_list=['--pipeline-service-connection-id', '--pipeline-sc-id'],
                          help='Project-scoped GitHub service connection ID (GUID) attached at '
                               'create time for pipeline rewiring. Required for full auto-discovery '
                               'when combined with --enable-auto-discover-pipelines; optional in '


### PR DESCRIPTION
Resolve the 4 azdev linter violations failing the azure-cli-extensions release lint:

- broken_site_link (group long-summary, target-repository help): backtick-wrap URLs

- disallowed_html_tag (repository-mapping help): backtick-wrap <sourceRepoId>=<targetOwner>/<targetRepo>

- option_length_too_long (>22): add short aliases --enable-boards-gh, --auto-discover, --pipeline-sc-id
