### PR TITLE
Fix apiVersionToFloat crashing on preview API versions with a sub-version

### DIFF
--- a/azure-devops/azext_devops/dev/team/invoke.py
+++ b/azure-devops/azext_devops/dev/team/invoke.py
@@ -135,7 +135,7 @@ def invoke(area=None, resource=None,
 
 
 def apiVersionToFloat(apiVersion):
-    apiVersion = apiVersion.replace('-preview', '')
+    apiVersion = apiVersion.split('-preview')[0]
 
     return float(apiVersion)
 

--- a/azure-devops/azext_devops/tests/latest/team/test_invoke.py
+++ b/azure-devops/azext_devops/tests/latest/team/test_invoke.py
@@ -1,0 +1,24 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import unittest
+
+from azext_devops.dev.team.invoke import apiVersionToFloat
+
+
+class TestApiVersionToFloat(unittest.TestCase):
+
+    def test_plain_version(self):
+        self.assertEqual(apiVersionToFloat('7.1'), 7.1)
+
+    def test_preview_version_without_subversion(self):
+        self.assertEqual(apiVersionToFloat('7.1-preview'), 7.1)
+
+    def test_preview_version_with_subversion(self):
+        # e.g. "7.1-preview.1" - the sub-version suffix used to break float() conversion
+        self.assertEqual(apiVersionToFloat('7.1-preview.1'), 7.1)
+
+    def test_preview_version_with_multi_digit_subversion(self):
+        self.assertEqual(apiVersionToFloat('5.0-preview.10'), 5.0)


### PR DESCRIPTION
## Summary

`az devops invoke --api-version <X.Y-preview.N>` fails with `could not convert string to float: '<X.Y.N>'`.

`apiVersionToFloat` only strips the literal `-preview` substring:

```python
def apiVersionToFloat(apiVersion):
    apiVersion = apiVersion.replace('-preview', '')
    return float(apiVersion)
```

For an input like `7.1-preview.1`, this leaves `7.1.1` behind (the sub-version suffix stays attached), which `float()` can't parse.

## Fix

Split on `-preview` and keep only the part before it, so the whole preview marker (including any sub-version) is dropped:

```python
def apiVersionToFloat(apiVersion):
    apiVersion = apiVersion.split('-preview')[0]
    return float(apiVersion)
```

This is the only call site of `apiVersionToFloat` in the codebase, and the parsed float is only used for a local version comparison against `resource_location.max_version` (line 91) — the original, unmodified `api_version` string is still passed through unchanged to the actual HTTP client call (line 103), so this only fixes the local comparison logic without touching wire behavior.

## Test plan

- Added `azext_devops/tests/latest/team/test_invoke.py` covering plain versions, `X.Y-preview`, `X.Y-preview.N`, and multi-digit sub-versions.
- Manually verified the fixed function against the exact failing input from the linked issues.

Fixes #946
Fixes #1454