### PR TITLE
Fix a Azure article in pipelines help text

### DIFF
--- a/azure-devops/azext_devops/dev/pipelines/_help.py
+++ b/azure-devops/azext_devops/dev/pipelines/_help.py
@@ -129,7 +129,7 @@ def load_pipelines_help():
            az pipelines create --name 'ContosoBuild' --description 'Pipeline for contoso project'
            --repository SampleOrg/SampleRepoName --branch master --repository-type github
 
-      - name: Create an Azure Pipeline for a repository hosted in a Azure Repo in the same project
+      - name: Create an Azure Pipeline for a repository hosted in an Azure Repo in the same project
         text: |
           az pipelines create --name 'ContosoBuild' --description 'Pipeline for contoso project'
           --repository SampleRepoName --branch master --repository-type tfsgit

--- a/azure-devops/azext_devops/dev/pipelines/pipeline_create.py
+++ b/azure-devops/azext_devops/dev/pipelines/pipeline_create.py
@@ -55,7 +55,7 @@ def pipeline_create(name, description=None, repository=None, branch=None, yml_pa
     :param description: Description for the new pipeline
     :type description: str
     :param repository: Repository for which the pipeline needs to be configured.
-    Can be clone url of the git repository or name of the repository for a Azure Repos
+    Can be clone url of the git repository or name of the repository for an Azure Repos
     or Owner/RepoName in case of GitHub repository.
     If omitted it will be auto-detected from the remote url of local git repository.
     If name is mentioned instead of url, --repository-type argument is also required.


### PR DESCRIPTION
## Summary
Addresses Azure/azure-cli-extensions#8102

Updates pipelines create help and repository parameter docs from `a Azure` to `an Azure` so the article matches vowel sound usage.

## Test plan
* [ ] Confirm `az pipelines create -h` example text uses `an Azure Repo`
* [ ] Confirm repository parameter help uses `an Azure Repos`