### PR TITLE
Harden Azure DevOps Git remote validation

### DIFF
--- a/azure-devops/azext_devops/dev/common/services.py
+++ b/azure-devops/azext_devops/dev/common/services.py
@@ -30,7 +30,9 @@ from .const import (DEFAULTS_SECTION,
 from ._credentials import get_credential
 from .git import get_remote_url
 from .vsts_git_url_info import VstsGitUrlInfo
-from .uri import uri_parse_instance_from_git_uri, is_valid_url
+from .uri import (canonicalize_azure_devops_organization_url,
+                  uri_parse_instance_from_git_uri,
+                  is_valid_url)
 from .uuid import is_uuid
 from .telemetry import vsts_tracking_data, init_telemetry
 
@@ -38,6 +40,10 @@ logger = get_logger(__name__)
 
 
 def get_connection(organization):
+    organization = canonicalize_azure_devops_organization_url(organization)
+    if organization is None:
+        raise CLIError('The Azure DevOps CLI extension works only with Azure DevOps Services (cloud). '
+                       'It doesn\'t support Azure DevOps Server (on-premises).')
     organization = organization.lower()
     if organization not in _connection:
         credentials = _get_credentials(organization)
@@ -86,6 +92,10 @@ def _get_credentials(organization):
 def validate_token_for_instance(organization, credentials):
     logger.debug("instance recieved in validate_token_for_instance %s", organization)
     organization = uri_parse_instance_from_git_uri(organization)
+    organization = canonicalize_azure_devops_organization_url(organization)
+    if organization is None:
+        logger.debug("Rejected invalid Azure DevOps organization URL during token validation.")
+        return False
     logger.debug("instance processed in validate_token_for_instance %s", organization)
     connection = _get_connection(organization, credentials)
     core_client = connection.get_client(VSTS_MODULE + 'v5_0.core.core_client.CoreClient')
@@ -166,6 +176,9 @@ def get_token_from_az_login(profile, tenant):
 
 
 def _get_connection(organization, credentials):
+    organization = canonicalize_azure_devops_organization_url(organization)
+    if organization is None:
+        raise CLIError('Refusing to attach credentials to an invalid Azure DevOps organization URL.')
     return Connection(get_base_url(organization), creds=credentials,
                       user_agent='devOpsCli/{}'.format(VERSION))
 
@@ -443,9 +456,7 @@ def get_project_id_from_name(organization, project):
 
 
 def check_organization_in_azure(organization):
-    startsWith = organization.startswith("https://dev.azure.com/")
-    endsWith = organization.rstrip("/").endswith(".visualstudio.com")
-    return startsWith or endsWith
+    return canonicalize_azure_devops_organization_url(organization) is not None
 
 
 _connection_data = {}

--- a/azure-devops/azext_devops/dev/common/uri.py
+++ b/azure-devops/azext_devops/dev/common/uri.py
@@ -49,7 +49,7 @@ def parse_azure_devops_git_remote(remote_url):
     return None
 
 
-def canonicalize_azure_devops_organization_url(url):
+def canonicalize_azure_devops_organization_url(url):  # pylint: disable=too-many-return-statements
     if not url or _UNSAFE_URL_CHARACTERS.search(url):
         return None
 
@@ -119,7 +119,7 @@ def is_valid_url(url):
     return True
 
 
-def _parse_azure_devops_https_git_remote(remote_url):
+def _parse_azure_devops_https_git_remote(remote_url):  # pylint: disable=too-many-return-statements
     parsed_url = _parse_safe_https_url(remote_url, allow_userinfo=True)
     if parsed_url is None:
         return None
@@ -148,7 +148,7 @@ def _parse_azure_devops_https_git_remote(remote_url):
     return AzureDevOpsGitRemote(repository_url, organization_url, host)
 
 
-def _parse_azure_devops_ssh_git_remote(remote_url):
+def _parse_azure_devops_ssh_git_remote(remote_url):  # pylint: disable=too-many-return-statements
     parsed_url = None
     lowered_url = remote_url.lower()
     if lowered_url.startswith('ssh://'):
@@ -213,7 +213,7 @@ def _parse_azure_devops_ssh_git_remote(remote_url):
     return AzureDevOpsGitRemote(repository_url, organization_url, https_host)
 
 
-def _parse_safe_https_url(url, allow_userinfo):
+def _parse_safe_https_url(url, allow_userinfo):  # pylint: disable=too-many-return-statements
     if _UNSAFE_URL_CHARACTERS.search(url):
         return None
 

--- a/azure-devops/azext_devops/dev/common/uri.py
+++ b/azure-devops/azext_devops/dev/common/uri.py
@@ -9,6 +9,18 @@ except ImportError:
     from urllib import quote
     from urlparse import urlparse
 
+import re
+from collections import namedtuple
+
+
+AzureDevOpsGitRemote = namedtuple(
+    'AzureDevOpsGitRemote',
+    ['repository_url', 'organization_url', 'host'])
+
+_UNSAFE_URL_CHARACTERS = re.compile(r'[\x00-\x20\x7f\\]')
+_SAFE_USERINFO = re.compile(r'^[A-Za-z0-9._-]+$')
+_SAFE_HOST_LABEL = re.compile(r'^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$')
+
 
 def uri_parse(url):
     # Special handling for NEW ssh urls which do not start with ssh://
@@ -24,18 +36,79 @@ def uri_quote(query_data):
     return quote(query_data)
 
 
+def parse_azure_devops_git_remote(remote_url):
+    # Reject characters that URL parsers and HTTP transports may interpret differently.
+    if not remote_url or _UNSAFE_URL_CHARACTERS.search(remote_url):
+        return None
+
+    lowered_url = remote_url.lower()
+    if lowered_url.startswith('https://'):
+        return _parse_azure_devops_https_git_remote(remote_url)
+    if lowered_url.startswith('ssh://') or '@' in remote_url:
+        return _parse_azure_devops_ssh_git_remote(remote_url)
+    return None
+
+
+def canonicalize_azure_devops_organization_url(url):
+    if not url or _UNSAFE_URL_CHARACTERS.search(url):
+        return None
+
+    git_remote = parse_azure_devops_git_remote(url)
+    if git_remote is not None:
+        return git_remote.organization_url
+
+    # Explicit --organization values use a narrower grammar than general service URLs.
+    parsed_url = _parse_safe_https_url(url, allow_userinfo=False)
+    if parsed_url is None:
+        return None
+
+    host, path_segments = parsed_url
+    if host == 'dev.azure.com' or _is_dev_azure_service_host(host):
+        if len(path_segments) != 1:
+            return None
+        return 'https://{host}/{organization}'.format(host=host, organization=path_segments[0])
+
+    if _is_visualstudio_host(host) and not path_segments:
+        return 'https://{host}/'.format(host=host)
+    return None
+
+
+def organization_url_from_azure_devops_url(url):
+    if not url or _UNSAFE_URL_CHARACTERS.search(url):
+        return None
+
+    parsed_url = _parse_safe_https_url(url, allow_userinfo=False)
+    if parsed_url is None:
+        return None
+
+    host, path_segments = parsed_url
+    # API and discovery URLs may contain paths after the organization segment.
+    if host == 'dev.azure.com' or _is_dev_azure_service_host(host):
+        if not path_segments:
+            return None
+        return 'https://{host}/{organization}'.format(host=host, organization=path_segments[0])
+
+    if _is_visualstudio_host(host):
+        return 'https://{host}/'.format(host=host)
+    return None
+
+
+def is_azure_devops_host(host):
+    if not host:
+        return False
+    host = host.lower()
+    return host in ('dev.azure.com', 'ssh.dev.azure.com') or _is_dev_azure_service_host(host) or \
+        _is_visualstudio_host(host) or host == 'vs-ssh.visualstudio.com'
+
+
 # Only works for hosted scenario
 def uri_parse_instance_from_git_uri(uri):
-    if "/_git" in uri:
-        parsed_uri = urlparse(uri)
-        # old Uri format
-        if "visualstudio.com" in uri:
-            return '{uri.scheme}://{uri.netloc}/'.format(uri=parsed_uri)
-        # new Uri format
-        if "dev.azure.com" in uri:
-            org_name = parsed_uri.path.strip("/").split("/")[0]
-            return parsed_uri.scheme + "://" + parsed_uri.hostname + "/" + org_name
-
+    git_remote = parse_azure_devops_git_remote(uri)
+    if git_remote is not None:
+        return git_remote.organization_url
+    organization_url = canonicalize_azure_devops_organization_url(uri)
+    if organization_url is not None:
+        return organization_url
     return uri
 
 
@@ -44,3 +117,161 @@ def is_valid_url(url):
     if not parsed_url.scheme or not parsed_url.netloc:
         return False
     return True
+
+
+def _parse_azure_devops_https_git_remote(remote_url):
+    parsed_url = _parse_safe_https_url(remote_url, allow_userinfo=True)
+    if parsed_url is None:
+        return None
+
+    host, path_segments, userinfo = parsed_url
+    if host == 'dev.azure.com':
+        # Modern clone URL: /{organization}/{project}/_git/{repository}.
+        if len(path_segments) != 4 or path_segments[2].lower() != '_git':
+            return None
+        organization = path_segments[0]
+        if userinfo is not None and userinfo.lower() != organization.lower():
+            return None
+        organization_url = 'https://dev.azure.com/{organization}'.format(organization=organization)
+    elif _is_visualstudio_host(host):
+        # Legacy URLs can include collection path segments before project/_git/repository.
+        if len(path_segments) < 3 or path_segments[-2].lower() != '_git':
+            return None
+        if userinfo is not None:
+            return None
+        organization_url = 'https://{host}/'.format(host=host)
+    else:
+        return None
+
+    repository_url = 'https://{host}/{path}'.format(
+        host=host, path='/'.join(path_segments))
+    return AzureDevOpsGitRemote(repository_url, organization_url, host)
+
+
+def _parse_azure_devops_ssh_git_remote(remote_url):
+    parsed_url = None
+    lowered_url = remote_url.lower()
+    if lowered_url.startswith('ssh://'):
+        parsed = urlparse(remote_url)
+        if parsed.scheme.lower() != 'ssh' or parsed.password or not parsed.username or \
+                parsed.query or parsed.fragment:
+            return None
+        try:
+            port = parsed.port
+        except ValueError:
+            return None
+        if port not in (None, 22):
+            return None
+        parsed_url = (parsed.username, parsed.hostname, parsed.path.strip('/').split('/'))
+    else:
+        # Match SCP-style SSH remotes such as git@ssh.dev.azure.com:v3/org/project/repo.
+        match = re.match(r'^([^@/:]+)@([^@/:]+):(.+)$', remote_url)
+        if match is None:
+            return None
+        # Split the match into SSH username, hostname, and repository path segments.
+        parsed_url = (match.group(1), match.group(2), match.group(3).strip('/').split('/'))
+
+    userinfo, host, path_segments = parsed_url
+    if not host or not _SAFE_USERINFO.match(userinfo) or any(not segment for segment in path_segments):
+        return None
+
+    host = host.lower()
+    if path_segments[0].lower() == 'v3':
+        # Current SSH form: v3/{organization}/{project}/{repository}.
+        if len(path_segments) != 4:
+            return None
+        organization, project, repository = path_segments[1:]
+    elif len(path_segments) == 3 and path_segments[1].lower() == '_ssh':
+        # Legacy visualstudio.com URI form: {project}/_ssh/{repository}.
+        project, repository = path_segments[0], path_segments[2]
+        organization = userinfo
+    elif len(path_segments) == 4 and path_segments[2].lower() == '_ssh':
+        # Legacy dev.azure.com URI form: {organization}/{project}/_ssh/{repository}.
+        organization, project, repository = path_segments[0], path_segments[1], path_segments[3]
+    else:
+        return None
+
+    if host == 'ssh.dev.azure.com':
+        # Convert the modern SSH endpoint to the equivalent canonical HTTPS URL.
+        if userinfo.lower() != 'git':
+            return None
+        https_host = 'dev.azure.com'
+        organization_url = 'https://dev.azure.com/{organization}'.format(organization=organization)
+        repository_path = '{organization}/{project}/_git/{repository}'.format(
+            organization=organization, project=project, repository=repository)
+    elif host == 'vs-ssh.visualstudio.com':
+        # The SSH username identifies the organization on the legacy endpoint.
+        if userinfo.lower() != organization.lower() or not _is_safe_host_label(organization):
+            return None
+        https_host = '{organization}.visualstudio.com'.format(organization=organization.lower())
+        organization_url = 'https://{host}/'.format(host=https_host)
+        repository_path = '{project}/_git/{repository}'.format(project=project, repository=repository)
+    else:
+        return None
+
+    repository_url = 'https://{host}/{path}'.format(host=https_host, path=repository_path)
+    return AzureDevOpsGitRemote(repository_url, organization_url, https_host)
+
+
+def _parse_safe_https_url(url, allow_userinfo):
+    if _UNSAFE_URL_CHARACTERS.search(url):
+        return None
+
+    match = re.match(r'^https://([^/?#]*)(/[^?#]*)?/?$', url, re.IGNORECASE)
+    if match is None:
+        return None
+
+    authority = match.group(1)
+    # Percent-encoding in the authority can produce different hosts across URL parsers.
+    if not authority or '%' in authority:
+        return None
+
+    userinfo = None
+    if '@' in authority:
+        if not allow_userinfo or authority.count('@') != 1:
+            return None
+        userinfo, authority = authority.split('@', 1)
+        if not userinfo or ':' in userinfo or not _SAFE_USERINFO.match(userinfo):
+            return None
+
+    if ':' in authority:
+        # Azure DevOps hosted endpoints support only HTTPS on the default port.
+        host, port = authority.rsplit(':', 1)
+        if port != '443':
+            return None
+    else:
+        host = authority
+
+    host = host.lower()
+    if not is_azure_devops_host(host):
+        return None
+
+    path = match.group(2) or ''
+    if '//' in path:
+        return None
+    path_segments = [segment for segment in path.strip('/').split('/') if segment]
+    if allow_userinfo:
+        return host, path_segments, userinfo
+    return host, path_segments
+
+
+def _is_visualstudio_host(host):
+    suffix = '.visualstudio.com'
+    if not host.endswith(suffix):
+        return False
+    organization = host[:-len(suffix)]
+    return organization != 'vs-ssh' and _is_safe_host_label(organization)
+
+
+def _is_dev_azure_service_host(host):
+    # Azure DevOps APIs can require a service-specific organization endpoint.
+    # Limit this to one Microsoft-controlled DNS label directly under dev.azure.com.
+    suffix = '.dev.azure.com'
+    if not host.endswith(suffix):
+        return False
+    service = host[:-len(suffix)]
+    return service != 'ssh' and _is_safe_host_label(service)
+
+
+def _is_safe_host_label(label):
+    return bool(_SAFE_HOST_LABEL.match(label))

--- a/azure-devops/azext_devops/dev/common/vsts_git_url_info.py
+++ b/azure-devops/azext_devops/dev/common/vsts_git_url_info.py
@@ -7,7 +7,9 @@ from msrest.serialization import Model
 from knack.log import get_logger
 
 from .file_cache import get_cli_cache
-from .uri import uri_parse
+from .uri import (is_azure_devops_host,
+                  organization_url_from_azure_devops_url,
+                  parse_azure_devops_git_remote)
 
 logger = get_logger(__name__)
 
@@ -26,7 +28,10 @@ class VstsGitUrlInfo():
             logger.debug("Remote url: %s", remote_url)
             models = {'_RemoteInfo': self._RemoteInfo}
 
-            remote_url = remote_url.lower()
+            parsed_remote = parse_azure_devops_git_remote(remote_url)
+            if parsed_remote is None:
+                return
+            remote_url = parsed_remote.repository_url
             remote_info = None
             if _git_remote_info_cache[remote_url]:
                 deserializer = Deserializer(models)
@@ -35,20 +40,29 @@ class VstsGitUrlInfo():
                 except DeserializationError as ex:
                     logger.debug(ex, exc_info=True)
                 if remote_info is not None:
-                    self.project = remote_info.project
-                    self.repo = remote_info.repository
-                    self.uri = remote_info.server_url
+                    organization_url = organization_url_from_azure_devops_url(remote_info.server_url)
+                    if organization_url is not None:
+                        self.project = remote_info.project
+                        self.repo = remote_info.repository
+                        self.uri = organization_url
+                    else:
+                        remote_info = None
             if remote_info is None:
                 vsts_info = self.get_vsts_info(remote_url)
                 if vsts_info is not None:
-                    self.project = vsts_info.repository.project.id
-                    self.repo = vsts_info.repository.id
                     apis_path_segment = '/_apis/'
                     apis_path_segment_pos = vsts_info.repository.url.find(apis_path_segment)
                     if apis_path_segment_pos >= 0:
-                        self.uri = vsts_info.repository.url[:apis_path_segment_pos]
+                        organization_url = organization_url_from_azure_devops_url(
+                            vsts_info.repository.url[:apis_path_segment_pos])
                     else:
-                        self.uri = vsts_info.server_url
+                        organization_url = organization_url_from_azure_devops_url(vsts_info.server_url)
+                    if organization_url is None:
+                        logger.warning('Auto-detect returned an invalid Azure DevOps organization URL.')
+                        return
+                    self.project = vsts_info.repository.project.id
+                    self.repo = vsts_info.repository.id
+                    self.uri = organization_url
                     serializer = Serializer(models)
                     try:
                         _git_remote_info_cache[remote_url] = \
@@ -61,41 +75,12 @@ class VstsGitUrlInfo():
     def get_vsts_info(remote_url):
         from azext_devops.devops_sdk.v5_0.git.git_client import GitClient
         from .services import _get_credentials
-        components = uri_parse(remote_url.lower())
-        if components.scheme == 'ssh':
-            # Convert to https url.
-            netloc = VstsGitUrlInfo.convert_ssh_netloc_to_https_netloc(components.netloc)
-            if netloc is None:
-                return None
-            # New ssh urls do not have _ssh so path is like org/project/repo
-            # We need to convert it into project/_git/repo/ or org/project/_git/repo for dev.azure.com urls
-            path = components.path
-            ssh_path_segment = '_ssh/'
-            ssh_path_segment_pos = components.path.find(ssh_path_segment)
-            if ssh_path_segment_pos < 0:  # new ssh url
-                path_vals = components.path.strip('/').split('/')
-                if path_vals and len(path_vals) == 3:
-                    if 'visualstudio.com' in netloc:
-                        path = '{proj}/{git}/{repo}'.format(proj=path_vals[1], git='_git', repo=path_vals[2])
-                    elif 'dev.azure.com' in netloc:
-                        path = '{org}/{proj}/{git}/{repo}'.format(
-                            org=path_vals[0], proj=path_vals[1], git='_git', repo=path_vals[2])
-                else:
-                    logger.debug("Unsupported url format encountered in git repo url discovery.")
-                uri = 'https://' + netloc + '/' + path
-            else:  # old ssh urls
-                uri = 'https://' + netloc + '/' + path.strip('/')
-                ssh_path_segment_pos = uri.find(ssh_path_segment)
-                if ssh_path_segment_pos >= 0:
-                    uri = uri[:ssh_path_segment_pos] + '_git/' + uri[ssh_path_segment_pos + len(ssh_path_segment):]
-        else:
-            uri = remote_url
-        # Validate the resolved host before sending any credentials
-        resolved_components = uri_parse(uri.lower())
-        if not _is_azure_devops_host(resolved_components.netloc):
+        parsed_remote = parse_azure_devops_git_remote(remote_url)
+        if parsed_remote is None:
             logger.warning('Skipping auto-detect: remote URL host is not a known Azure DevOps host.')
             return None
-        credentials = _get_credentials(uri)
+        uri = parsed_remote.repository_url
+        credentials = _get_credentials(parsed_remote.organization_url)
         try:
             return GitClient.get_vsts_info_by_remote_url(uri, credentials=credentials)
         except Exception as ex:  # pylint: disable=broad-except
@@ -129,17 +114,7 @@ class VstsGitUrlInfo():
 
     @staticmethod
     def is_vsts_url_candidate(url):
-        if url is None:
-            return False
-        components = uri_parse(url.lower())
-        if not _is_azure_devops_host(components.netloc):
-            return False
-        if components.path is not None \
-            and (components.path.find('/_git/') >= 0 or components.path.find('/_ssh/') >= 0 or
-                 components.scheme == 'ssh'):
-            return True
-
-        return False
+        return parse_azure_devops_git_remote(url) is not None
 
     class _RemoteInfo(Model):
 
@@ -158,15 +133,10 @@ class VstsGitUrlInfo():
 
 def _is_azure_devops_host(netloc):
     """Return True only for known Azure DevOps hosted service hostnames."""
-    if netloc is None:
+    if netloc is None or '@' in netloc or '\\' in netloc:
         return False
-    # Strip optional user@ prefix (e.g. "org@vs-ssh.visualstudio.com")
-    host = netloc.split('@')[-1].split(':')[0].lower()
-    if host == 'dev.azure.com' or host == 'ssh.dev.azure.com':
-        return True
-    if host.endswith('.visualstudio.com'):
-        return True
-    return False
+    host = netloc.rsplit(':', 1)[0].lower()
+    return is_azure_devops_host(host)
 
 
 _git_remote_info_cache = get_cli_cache('remotes', 0)

--- a/azure-devops/azext_devops/devops_sdk/v5_0/git/git_client.py
+++ b/azure-devops/azext_devops/devops_sdk/v5_0/git/git_client.py
@@ -28,6 +28,10 @@ class GitClient(GitClientBase):
     def get_vsts_info_by_remote_url(remote_url, credentials,
                                     suppress_fedauth_redirect=True,
                                     force_msa_pass_through=True):
+        from azext_devops.dev.common.uri import parse_azure_devops_git_remote
+        parsed_remote = parse_azure_devops_git_remote(remote_url)
+        if parsed_remote is None or parsed_remote.repository_url != remote_url:
+            raise ValueError('Refusing to attach credentials to an invalid Azure DevOps repository URL.')
         request = ClientRequest(method='GET', url=remote_url.rstrip('/') + '/vsts/info')
         headers = {'Accept': 'application/json'}
         if suppress_fedauth_redirect:

--- a/azure-devops/azext_devops/devops_sdk/v5_1/git/git_client.py
+++ b/azure-devops/azext_devops/devops_sdk/v5_1/git/git_client.py
@@ -28,6 +28,10 @@ class GitClient(GitClientBase):
     def get_vsts_info_by_remote_url(remote_url, credentials,
                                     suppress_fedauth_redirect=True,
                                     force_msa_pass_through=True):
+        from azext_devops.dev.common.uri import parse_azure_devops_git_remote
+        parsed_remote = parse_azure_devops_git_remote(remote_url)
+        if parsed_remote is None or parsed_remote.repository_url != remote_url:
+            raise ValueError('Refusing to attach credentials to an invalid Azure DevOps repository URL.')
         request = ClientRequest(method='GET', url=remote_url.rstrip('/') + '/vsts/info')
         headers = {'Accept': 'application/json'}
         if suppress_fedauth_redirect:

--- a/azure-devops/azext_devops/devops_sdk/v6_0/git/git_client.py
+++ b/azure-devops/azext_devops/devops_sdk/v6_0/git/git_client.py
@@ -28,6 +28,10 @@ class GitClient(GitClientBase):
     def get_vsts_info_by_remote_url(remote_url, credentials,
                                     suppress_fedauth_redirect=True,
                                     force_msa_pass_through=True):
+        from azext_devops.dev.common.uri import parse_azure_devops_git_remote
+        parsed_remote = parse_azure_devops_git_remote(remote_url)
+        if parsed_remote is None or parsed_remote.repository_url != remote_url:
+            raise ValueError('Refusing to attach credentials to an invalid Azure DevOps repository URL.')
         request = ClientRequest(method='GET', url=remote_url.rstrip('/') + '/vsts/info')
         headers = {'Accept': 'application/json'}
         if suppress_fedauth_redirect:

--- a/azure-devops/azext_devops/tests/latest/common/test_services.py
+++ b/azure-devops/azext_devops/tests/latest/common/test_services.py
@@ -21,7 +21,8 @@ from azext_devops.dev.common.services import (get_connection,
                                               clear_connection_cache,
                                               resolve_instance,
                                               resolve_instance_project_and_repo,
-                                              check_organization_in_azure)
+                                              check_organization_in_azure,
+                                              validate_token_for_instance)
 
 
 class TestServicesMethods(unittest.TestCase):    
@@ -80,6 +81,27 @@ class TestServicesMethods(unittest.TestCase):
     def test_check_organization_in_azure_with_ado_server_url(self):
         showWarning = check_organization_in_azure(self._TEST_ADO_SERVER_ORGANIZATION)
         self.assertEqual(False, showWarning)
+
+    def test_check_organization_in_azure_with_service_url(self):
+        self.assertTrue(check_organization_in_azure(
+            'https://artifacts.dev.azure.com/MyOrganization'))
+
+    def test_check_organization_in_azure_rejects_ambiguous_authority(self):
+        self.assertFalse(check_organization_in_azure(
+            'https://attacker.example\\@dev.azure.com/MyOrganization'))
+
+    def test_check_organization_in_azure_rejects_extra_path(self):
+        self.assertFalse(check_organization_in_azure(
+            'https://dev.azure.com/MyOrganization/Unexpected'))
+
+    def test_validate_token_rejects_ambiguous_authority_before_connection(self):
+        with patch('azext_devops.dev.common.services._get_connection') as mock_get_connection:
+            result = validate_token_for_instance(
+                'https://attacker.example\\@myorg.visualstudio.com/project/_git/repository',
+                credentials=object())
+
+        self.assertFalse(result)
+        mock_get_connection.assert_not_called()
 
     ORG_ERROR_STRING = ('--organization must be specified. The value should be the URI of your Azure DevOps '
                     'organization, for example: https://dev.azure.com/MyOrganization/. '

--- a/azure-devops/azext_devops/tests/latest/common/test_uri.py
+++ b/azure-devops/azext_devops/tests/latest/common/test_uri.py
@@ -4,7 +4,9 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-from azext_devops.dev.common.uri import (uri_parse_instance_from_git_uri)
+from azext_devops.dev.common.uri import (canonicalize_azure_devops_organization_url,
+                                         parse_azure_devops_git_remote,
+                                         uri_parse_instance_from_git_uri)
 
 
 class TestUriMethods(unittest.TestCase):
@@ -22,6 +24,56 @@ class TestUriMethods(unittest.TestCase):
         uri = "https://mseng.visualstudio.com/"
         result = uri_parse_instance_from_git_uri(uri)
         self.assertEqual(result, "https://mseng.visualstudio.com/")
+
+    def test_parse_azure_devops_git_remote_canonicalizes_https_userinfo(self):
+        result = parse_azure_devops_git_remote(
+            "https://mockorg@dev.azure.com/mockorg/mockproject/_git/mockrepo")
+        self.assertEqual(
+            result.repository_url,
+            "https://dev.azure.com/mockorg/mockproject/_git/mockrepo")
+
+    def test_parse_azure_devops_git_remote_rejects_ambiguous_authority(self):
+        self.assertIsNone(parse_azure_devops_git_remote(
+            "https://attacker.example\\@dev.azure.com/org/project/_git/repo"))
+        self.assertIsNone(parse_azure_devops_git_remote(
+            "https://attacker.example%5c@dev.azure.com/org/project/_git/repo"))
+        self.assertIsNone(parse_azure_devops_git_remote(
+            "https://user:password@dev.azure.com/org/project/_git/repo"))
+        self.assertIsNone(parse_azure_devops_git_remote(
+            "https://user@attacker.example@dev.azure.com/org/project/_git/repo"))
+
+    def test_parse_azure_devops_git_remote_rejects_spoofed_hosts(self):
+        self.assertIsNone(parse_azure_devops_git_remote(
+            "https://dev.azure.com.evil.example/org/project/_git/repo"))
+        self.assertIsNone(parse_azure_devops_git_remote(
+            "https://notvisualstudio.com/project/_git/repo"))
+
+    def test_canonicalize_azure_devops_organization_url(self):
+        self.assertEqual(
+            canonicalize_azure_devops_organization_url("https://dev.azure.com/MyOrg/"),
+            "https://dev.azure.com/MyOrg")
+        self.assertEqual(
+            canonicalize_azure_devops_organization_url("https://myorg.visualstudio.com/"),
+            "https://myorg.visualstudio.com/")
+        self.assertIsNone(canonicalize_azure_devops_organization_url(
+            "https://dev.azure.com.evil.example/MyOrg"))
+
+    def test_canonicalize_azure_devops_service_organization_url(self):
+        service_names = ('artifacts', 'feeds', 'pkgs', 'vssps', 'extmgmt', 'auditservice')
+        for service_name in service_names:
+            service_url = "https://{service}.dev.azure.com/MyOrg/".format(service=service_name)
+            with self.subTest(service_name=service_name):
+                self.assertEqual(
+                    canonicalize_azure_devops_organization_url(service_url),
+                    service_url.rstrip('/'))
+        self.assertIsNone(canonicalize_azure_devops_organization_url(
+            "https://evil.artifacts.dev.azure.com/MyOrg"))
+        self.assertIsNone(canonicalize_azure_devops_organization_url(
+            "https://artifacts.dev.azure.com/MyOrg/Unexpected"))
+
+    def test_service_organization_url_is_not_a_git_remote(self):
+        self.assertIsNone(parse_azure_devops_git_remote(
+            "https://artifacts.dev.azure.com/MyOrg/Project/_git/Repository"))
 
 
 if __name__ == '__main__':

--- a/azure-devops/azext_devops/tests/latest/common/test_vsts_git_url_info.py
+++ b/azure-devops/azext_devops/tests/latest/common/test_vsts_git_url_info.py
@@ -6,11 +6,18 @@
 import unittest
 try:
     # Attempt to load mock (works on Python 3.3 and above)
-    from unittest.mock import patch
+    from unittest.mock import Mock, patch
 except ImportError:
     # Attempt to load mock (works on Python version below 3.3)
-    from mock import patch
+    from mock import Mock, patch
+from azext_devops.devops_sdk.v5_0.git.git_client import GitClient
 from azext_devops.dev.common.vsts_git_url_info import VstsGitUrlInfo, _is_azure_devops_host
+
+
+class FakeCache(dict):
+
+    def __getitem__(self, key):
+        return self.get(key)
 
 
 class Test_VstsGitUrlInfo_Methods(unittest.TestCase):
@@ -71,7 +78,16 @@ class Test_VstsGitUrlInfo_Methods(unittest.TestCase):
                 mock_get_creds.assert_called_once()
                 get_vsts_info_url_param = mock_get_vsts_info.call_args_list[0][0]
                 self.assertEqual(
-                    'https://organization@dev.azure.com/organization/project/_git/repository'.lower(), get_vsts_info_url_param[0])
+                    'https://dev.azure.com/organization/project/_git/repository'.lower(), get_vsts_info_url_param[0])
+
+    def test_get_vsts_info_rejects_cross_parser_authority(self):
+        with patch('azext_devops.devops_sdk.v5_0.git.git_client.GitClient.get_vsts_info_by_remote_url') as mock_get_vsts_info:
+            with patch('azext_devops.dev.common.services._get_credentials') as mock_get_creds:
+                result = VstsGitUrlInfo.get_vsts_info(
+                    'https://attacker.example\\@dev.azure.com/org/project/_git/repo')
+                self.assertIsNone(result)
+                mock_get_creds.assert_not_called()
+                mock_get_vsts_info.assert_not_called()
 
     def test_get_vsts_info_rejects_arbitrary_host_with_git_path(self):
         """Credentials must never be sent to non-Azure DevOps hosts."""
@@ -90,6 +106,44 @@ class Test_VstsGitUrlInfo_Methods(unittest.TestCase):
                 self.assertIsNone(result)
                 mock_get_creds.assert_not_called()
                 mock_get_vsts_info.assert_not_called()
+
+    def test_get_vsts_info_client_rejects_noncanonical_url(self):
+        with self.assertRaises(ValueError):
+            GitClient.get_vsts_info_by_remote_url(
+                'https://organization@dev.azure.com/organization/project/_git/repository',
+                credentials=Mock())
+
+    def test_rejects_untrusted_vsts_info_response_url(self):
+        vsts_info = Mock()
+        vsts_info.repository.url = 'https://attacker.example/org/project/_apis/git/repositories/repository'
+        vsts_info.repository.project.id = 'project'
+        vsts_info.repository.id = 'repository'
+        vsts_info.server_url = 'https://attacker.example/'
+        cache = FakeCache()
+
+        with patch('azext_devops.dev.common.vsts_git_url_info._git_remote_info_cache', cache):
+            with patch.object(VstsGitUrlInfo, 'get_vsts_info', return_value=vsts_info):
+                result = VstsGitUrlInfo('https://dev.azure.com/org/project/_git/repository')
+
+        self.assertIsNone(result.uri)
+        self.assertNotIn('https://dev.azure.com/org/project/_git/repository', cache)
+
+    def test_revalidates_cached_organization_url(self):
+        remote_url = 'https://dev.azure.com/org/project/_git/repository'
+        cache = FakeCache({
+            remote_url: {
+                'project': 'project',
+                'repository': 'repository',
+                'serverUrl': 'https://attacker.example/'
+            }
+        })
+
+        with patch('azext_devops.dev.common.vsts_git_url_info._git_remote_info_cache', cache):
+            with patch.object(VstsGitUrlInfo, 'get_vsts_info', return_value=None) as mock_get_vsts_info:
+                result = VstsGitUrlInfo(remote_url)
+
+        self.assertIsNone(result.uri)
+        mock_get_vsts_info.assert_called_once_with(remote_url)
 
 
 class Test_IsVstsUrlCandidate(unittest.TestCase):
@@ -138,10 +192,10 @@ class Test_IsAzureDevOpsHost(unittest.TestCase):
         self.assertTrue(_is_azure_devops_host('vs-ssh.visualstudio.com'))
 
     def test_user_at_dev_azure_com(self):
-        self.assertTrue(_is_azure_devops_host('org@dev.azure.com'))
+        self.assertFalse(_is_azure_devops_host('org@dev.azure.com'))
 
     def test_git_at_ssh_dev_azure_com(self):
-        self.assertTrue(_is_azure_devops_host('git@ssh.dev.azure.com'))
+        self.assertFalse(_is_azure_devops_host('git@ssh.dev.azure.com'))
 
     def test_rejects_github(self):
         self.assertFalse(_is_azure_devops_host('github.com'))

--- a/azure-devops/azext_devops/tests/latest/pipelines/test_pipelines_build.py
+++ b/azure-devops/azext_devops/tests/latest/pipelines/test_pipelines_build.py
@@ -62,7 +62,7 @@ class TestPipelinesBuildMethods(AuthenticatedTests):
         self.mock_open_browser.assert_called_once_with("dummy_build", self._TEST_DEVOPS_ORGANIZATION)
 
     def test_show_build_with_detected_project_org(self):
-        _DUMMY_INSTANCE = 'dummy_instance'
+        _DUMMY_INSTANCE = 'https://dev.azure.com/dummyorganization'
         _DUMMY_PROJECT = 'dummy_project'
         _DUMMY_BUILD = 'dummy_build'
         _DUMMY_REPO = 'dummy_repo'


### PR DESCRIPTION
Canonicalize supported HTTPS and SSH remotes before credentials are acquired or sent, and add regression coverage for parser-confusion attacks.

Please make sure the code is following contribution guidelines in CONTRIBUTING.md

 - [ ] : This PR has a corresponding issue open in the Repository.
 - [ ] : Approach is signed off on the issue.
