### PR TITLE
docs(elm): simplify migrations help text and link to aka.ms/adoELM

### DIFF
--- a/azure-devops/azext_devops/dev/migration/_help.py
+++ b/azure-devops/azext_devops/dev/migration/_help.py
@@ -10,7 +10,7 @@ def load_migration_help():
     helps['devops migrations'] = """
     type: group
     short-summary: Manage enterprise live migrations.
-    long-summary: 'This command group is a part of the azure-devops extension and is in preview. Availability may be limited (for example, to 1P/allowlisted users). For ELM migrations, --org should be your Azure DevOps organization URL (for example: `https://dev.azure.com/myorg`).'
+    long-summary: 'The ELM migration command group is part of the azure-devops extension. Please refer to https://aka.ms/adoELM for more information.'
     """
 
     helps['devops migrations list'] = """

--- a/doc/migrations.md
+++ b/doc/migrations.md
@@ -1,7 +1,7 @@
 # Enterprise live migrations (ELM)
 
 The `az devops migrations` command group (Preview) manages enterprise live migrations for repositories.
-Availability may be limited (for example, to 1P/allowlisted users).
+For more information, see https://aka.ms/adoELM.
 
 ## Prerequisites
 

--- a/doc/migrations.md
+++ b/doc/migrations.md
@@ -1,7 +1,7 @@
 # Enterprise live migrations (ELM)
 
 The `az devops migrations` command group (Preview) manages enterprise live migrations for repositories.
-For more information, see https://aka.ms/adoELM.
+For more information, see [https://aka.ms/adoELM](https://aka.ms/adoELM).
 
 ## Prerequisites
 


### PR DESCRIPTION
Simplifies the ELM migrations help/doc wording to point users to https://aka.ms/adoELM instead of describing limited availability.

## Changes
- `azext_devops/dev/migration/_help.py`: `devops migrations` group long-summary now reads "The ELM migration command group is part of the azure-devops extension. Please refer to https://aka.ms/adoELM for more information." (The preview status tag/warning is still auto-generated by the framework, so it is not repeated in the text.)
- `doc/migrations.md`: replaced the "Availability may be limited" line with "For more information, see https://aka.ms/adoELM."